### PR TITLE
Allow to pull base image during build

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -36,7 +36,10 @@ function docker_build_with_version {
   cp ${DOCKERFILE_PATH} "${DOCKERFILE_PATH}.version"
   git_version=$(git rev-parse --short HEAD)
   echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
-  docker build -t ${IMAGE_NAME} -f "${dockerfile}.version" .
+  if [[ "${UPDATE_BASE}" == "1" ]]; then
+    BUILD_OPTIONS+=" --pull=true"
+  fi
+  docker build ${BUILD_OPTIONS} -t ${IMAGE_NAME} -f "${dockerfile}.version" .
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash "${dockerfile}.version"
   fi

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -10,6 +10,7 @@ endif
 
 script_env = \
 	SKIP_SQUASH=$(SKIP_SQUASH)                      \
+        UPDATE_BASE=$(UPDATE_BASE)                      \
 	VERSIONS="$(VERSIONS)"                          \
 	OS=$(OS)                                        \
 	VERSION=$(VERSION)                              \


### PR DESCRIPTION
This PR adds option to update base image during build. So user can add "UPDATE_BASE=1" to `make` command and `docker build` will try to pull latest base image - see "--pull" option in https://docs.docker.com/engine/reference/commandline/build/

@hhorak @bparees Please test. I will create same PR for other repositories after this PR is complete and merged. Thanks.