### PR TITLE
Fix using subscription in container

### DIFF
--- a/10.0/Dockerfile.rhel7
+++ b/10.0/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:7.2
+FROM rhel7
 
 # MariaDB image for OpenShift.
 #

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:7.2
+FROM rhel7
 
 # MariaDB image for OpenShift.
 #


### PR DESCRIPTION
Enabling host repositories didn't work with docker 1.10 and newer inside OpenStack. It was fixed in latest rhel7 base release, so using 'rhel7' base image is required for RHEL CI. Postgresql PR - sclorg/postgresql-container#150

Also to enable repositories inside container running 'yum' first is required - see https://access.redhat.com/solutions/1443553 . Similar to sclorg/s2i-base-container#99 .


@hhorak @bparees Please take a look and merge.