### PR TITLE
Using empty --basedir for mysql_install_db 

### DIFF
--- a/10.1/root/usr/share/container-scripts/mysql/common.sh
+++ b/10.1/root/usr/share/container-scripts/mysql/common.sh
@@ -89,7 +89,8 @@ function initialize_database() {
   log_info 'Initializing database ...'
   log_info 'Running mysql_install_db ...'
   # Using --rpm since we need mysql_install_db behaves as in RPM
-  mysql_install_db --rpm --datadir=$MYSQL_DATADIR
+  # Using empty --basedir to work-around https://bugzilla.redhat.com/show_bug.cgi?id=1406391
+  mysql_install_db --rpm --datadir=$MYSQL_DATADIR --basedir=''
   start_local_mysql "$@"
 
   if [ -v MYSQL_RUNNING_AS_SLAVE ]; then


### PR DESCRIPTION
This will make the container image working with newest RPMs, so it is a work-around for https://bugzilla.redhat.com/show_bug.cgi?id=1406391

However, we should remove this once the RPMs are fixed.