### PR TITLE
Port dockerfile for fedora and include it as addition

### DIFF
--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -1,0 +1,64 @@
+FROM fedora:25
+
+MAINTAINER "Honza Horak" <hhorak@redhat.com>
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=10.1 \
+    HOME=/var/lib/mysql
+
+LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
+      io.k8s.description="MariaDB is a multi-user, multi-threaded SQL database server" \
+      io.k8s.display-name="MariaDB 10.1" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb101,galera"
+
+ENV NAME=mariadb VERSION=10.1 RELEASE=1 ARCH=x86_64
+LABEL BZComponent="$NAME" \
+        Name="$FGC/$NAME" \
+        Version="$VERSION" \
+        Release="$RELEASE.$DISTTAG" \
+        Architecture="$ARCH"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils mariadb-server policycoreutils" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    dnf clean all && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# On Fedora, we fake missing python binary. In case user installs the python2
+# in the container, this hack will be removed by installing /usr/bin/python from RPM.
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+ADD root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+RUN rm -rf /etc/my.cnf.d/*
+RUN /usr/libexec/container-setup
+
+VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]


### PR DESCRIPTION
This only demonstrates that we can use the same sources for the container for SCL and Fedora packages. It does not influence any existing sources.