### PR TITLE
Fix tests for docker 1.12 (changed docker exec parsing)

### DIFF
--- a/10.0/test/run
+++ b/10.0/test/run
@@ -204,7 +204,7 @@ function assert_login_access() {
 
 function assert_local_access() {
   local id="$1" ; shift
-  docker exec $(get_cid "$id") bash -c mysql <<< "SELECT 1;"
+  docker exec $(get_cid "$id") bash -c 'mysql <<< "SELECT 1;"'
 }
 
 # Make sure the invocation of docker run fails.

--- a/10.1/test/run
+++ b/10.1/test/run
@@ -204,7 +204,7 @@ function assert_login_access() {
 
 function assert_local_access() {
   local id="$1" ; shift
-  docker exec $(get_cid "$id") bash -c mysql <<< "SELECT 1;"
+  docker exec $(get_cid "$id") bash -c 'mysql <<< "SELECT 1;"'
 }
 
 # Make sure the invocation of docker run fails.


### PR DESCRIPTION
Upgrade from docker 1.10 to docker 1.12 changed format of parsing `docker exec` arguments.

So `docker exec $(get_cid "$id") bash -c mysql <<< "SELECT 1;"` is waiting forever. Quotes or `-i` is required to make test passing.

EDIT: `assert_local_access` test was not working right with docker 1.10. (`mysql` got no input, so it succeded)