### PR TITLE
add rhel6 10.1 build

### DIFF
--- a/10.1/Dockerfile.rhel6
+++ b/10.1/Dockerfile.rhel6
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel6
 
 # MariaDB image for OpenShift.
 #
@@ -12,6 +12,7 @@ FROM registry.access.redhat.com/rhel7
 
 ENV MYSQL_VERSION=10.1 \
     HOME=/var/lib/mysql
+    PATH=$PATH:/sbin
 
 ENV SUMMARY="MariaDB 10.1 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
@@ -38,9 +39,9 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils gettext hostname && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum-config-manager --enable rhel-7-server-optional-rpms && \
+RUN yum install -y yum-utils gettext net-tools && \
+    yum-config-manager --enable rhel-server-rhscl-6-rpms && \
+    yum-config-manager --enable rhel-6-server-optional-rpms && \
     INSTALL_PKGS="rsync tar bind-utils rh-mariadb101" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/10.1/Dockerfile.rhel6
+++ b/10.1/Dockerfile.rhel6
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel6
+FROM rhel6
 
 # MariaDB image for OpenShift.
 #

--- a/10.1/Dockerfile.rhel6
+++ b/10.1/Dockerfile.rhel6
@@ -29,7 +29,7 @@ LABEL summary="$SUMMARY" \
 
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="rh-mariadb101-docker" \
-      name="rhscl/mariadb-101-rhel7" \
+      name="rhscl/mariadb-101-rhel6" \
       version="10.1" \
       release="1" \
       architecture="x86_64"

--- a/10.1/Dockerfile.rhel6
+++ b/10.1/Dockerfile.rhel6
@@ -11,7 +11,7 @@ FROM registry.access.redhat.com/rhel6
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.1 \
-    HOME=/var/lib/mysql
+    HOME=/var/lib/mysql \
     PATH=$PATH:/sbin
 
 ENV SUMMARY="MariaDB 10.1 SQL database server" \
@@ -39,10 +39,12 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils gettext net-tools && \
+RUN yum install -y --setopt=tsflags=nodocs yum-utils && \
+    yum-config-manager --disable \* &> /dev/null && \
+    yum-config-manager --enable rhel-6-server-rpms && \
     yum-config-manager --enable rhel-server-rhscl-6-rpms && \
     yum-config-manager --enable rhel-6-server-optional-rpms && \
-    INSTALL_PKGS="rsync tar bind-utils rh-mariadb101" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils rh-mariadb101" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -38,10 +38,12 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils gettext hostname && \
+RUN yum install -y yum-utils && \
+    yum-config-manager --disable \* &> /dev/null && \
+    yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="rsync tar bind-utils rh-mariadb101" && \
+    INSTALL_PKGS="rsync tar gettext hostname bind-utils rh-mariadb101" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM rhel7
 
 # MariaDB image for OpenShift.
 #

--- a/10.1/root/usr/bin/cgroup-limits
+++ b/10.1/root/usr/bin/cgroup-limits
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         "NUMBER_OF_CORES": get_number_of_cores()
     }
 
-    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+    env_vars = dict([(k, v) for k, v in env_vars.items() if v is not None])
 
     if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
         env_vars["NO_MEMORY_LIMIT"] = "true"

--- a/10.1/root/usr/share/container-scripts/mysql/README.md
+++ b/10.1/root/usr/share/container-scripts/mysql/README.md
@@ -4,8 +4,8 @@ MariaDB Docker image
 This container image includes MariaDB server 10.1 for OpenShift and general usage.
 Users can choose between RHEL and CentOS based images.
 
-Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called
-Dockerfile.rhel7.
+Dockerfile for CentOS is called Dockerfile, Dockerfiles for RHEL are called
+Dockerfile.rhel6 & Dockerfile.rhel7.
 
 Environment variables and volumes
 ----------------------------------

--- a/10.1/root/usr/share/container-scripts/mysql/common.sh
+++ b/10.1/root/usr/share/container-scripts/mysql/common.sh
@@ -93,12 +93,12 @@ function initialize_database() {
   mysql_install_db --rpm --datadir=$MYSQL_DATADIR --basedir=''
   start_local_mysql "$@"
 
-  if [ -v MYSQL_RUNNING_AS_SLAVE ]; then
+  if [ ! -z ${MYSQL_RUNNING_AS_SLAVE+x} ]; then
     log_info 'Initialization finished'
     return 0
   fi
 
-  if [ -v MYSQL_RUNNING_AS_MASTER ]; then
+  if [ ! -z ${MYSQL_RUNNING_AS_MASTER+x} ]; then
     # Save master status into a separate database.
     STATUS_INFO=$(mysql $admin_flags -e 'SHOW MASTER STATUS\G')
     BINLOG_POSITION=$(echo "$STATUS_INFO" | grep 'Position:' | head -n 1 | sed -e 's/^\s*Position: //')
@@ -115,17 +115,17 @@ EOSQL
   fi
 
   # Do not care what option is compulsory here, just create what is specified
-  if [ -v MYSQL_USER ]; then
+  if [ ! -z ${MYSQL_USER+x} ]; then
     log_info "Creating user specified by MYSQL_USER (${MYSQL_USER}) ..."
 mysql $mysql_flags <<EOSQL
     CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
 EOSQL
   fi
 
-  if [ -v MYSQL_DATABASE ]; then
+  if [ ! -z ${MYSQL_DATABASE+x} ]; then
     log_info "Creating database ${MYSQL_DATABASE} ..."
     mysqladmin $admin_flags create "${MYSQL_DATABASE}"
-    if [ -v MYSQL_USER ]; then
+    if [ ! -z ${MYSQL_USER+x} ]; then
       log_info "Granting privileges to user ${MYSQL_USER} for ${MYSQL_DATABASE} ..."
 mysql $mysql_flags <<EOSQL
       GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
@@ -134,7 +134,7 @@ EOSQL
     fi
   fi
 
-  if [ -v MYSQL_ROOT_PASSWORD ]; then
+  if [ ! -z ${MYSQL_ROOT_PASSWORD+x} ]; then
     log_info "Setting password for MySQL root user ..."
 mysql $mysql_flags <<EOSQL
     CREATE USER IF NOT EXISTS 'root'@'%';

--- a/10.1/root/usr/share/container-scripts/mysql/passwd-change.sh
+++ b/10.1/root/usr/share/container-scripts/mysql/passwd-change.sh
@@ -1,6 +1,6 @@
 # Set the password for MySQL user and root everytime this container is started.
 # This allows to change the password by editing the deployment configuration.
-if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
+if [[ ! -z ${MYSQL_USER+x} && ! -z ${MYSQL_PASSWORD+x} ]]; then
   mysql $mysql_flags <<EOSQL
     SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
 EOSQL
@@ -8,7 +8,7 @@ fi
 
 # The MYSQL_ROOT_PASSWORD is optional, therefore we need to either enable remote
 # access with a password if the variable is set or disable remote access otherwise.
-if [ -v MYSQL_ROOT_PASSWORD ]; then
+if [ ! -z ${MYSQL_ROOT_PASSWORD+x} ]; then
   # create a user if it doesn't exist and set its password
   mysql $mysql_flags <<EOSQL
     CREATE USER IF NOT EXISTS 'root'@'%';

--- a/10.1/root/usr/share/container-scripts/mysql/validate-replication-variables.sh
+++ b/10.1/root/usr/share/container-scripts/mysql/validate-replication-variables.sh
@@ -1,6 +1,6 @@
 function validate_replication_variables() {
-  if ! [[ -v MYSQL_DATABASE && -v MYSQL_MASTER_USER && -v MYSQL_MASTER_PASSWORD && \
-        ( "${MYSQL_RUNNING_AS_SLAVE:-0}" != "1" || -v MYSQL_MASTER_SERVICE_NAME ) ]]; then
+  if ! [[ ! -z ${MYSQL_DATABASE+x} && ! -z ${MYSQL_MASTER_USER+x} && ! -z ${MYSQL_MASTER_PASSWORD+x} && \
+        ( "${MYSQL_RUNNING_AS_SLAVE:-0}" != "1" || ! -z ${MYSQL_MASTER_SERVICE_NAME+x} ) ]]; then
     echo
     echo "For master/slave replication, you have to specify following environment variables:"
     echo "  MYSQL_MASTER_SERVICE_NAME (slave only)"

--- a/10.1/root/usr/share/container-scripts/mysql/validate-variables.sh
+++ b/10.1/root/usr/share/container-scripts/mysql/validate-variables.sh
@@ -28,14 +28,14 @@ function usage() {
 
 function validate_variables() {
   # Check basic sanity of specified variables
-  if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
+  if [[ ! -z ${MYSQL_USER+x} && ! -z ${MYSQL_PASSWORD+x} ]]; then
     [[ "$MYSQL_USER"     =~ $mysql_identifier_regex ]] || usage "Invalid MySQL username"
     [ ${#MYSQL_USER} -le 16 ] || usage "MySQL username too long (maximum 16 characters)"
     [[ "$MYSQL_PASSWORD" =~ $mysql_password_regex   ]] || usage "Invalid password"
     user_specified=1
   fi
 
-  if [ -v MYSQL_ROOT_PASSWORD ]; then
+  if [ ! -z ${MYSQL_ROOT_PASSWORD+x} ]; then
     [[ "$MYSQL_ROOT_PASSWORD" =~ $mysql_password_regex ]] || usage "Invalid root password"
     root_specified=1
   fi
@@ -60,16 +60,16 @@ function validate_variables() {
 
   # If the root user is not specified, database name is required
   if [[ "${root_specified:-0}" == "0" ]]; then
-    [ -v MYSQL_DATABASE ] || usage "You need to specify database name or root password"
+    [ ! -z ${MYSQL_DATABASE+x} ] || usage "You need to specify database name or root password"
   fi
 
-  if [ -v MYSQL_DATABASE ]; then
+  if [ ! -z ${MYSQL_DATABASE+x} ]; then
     [[ "$MYSQL_DATABASE" =~ $mysql_identifier_regex ]] || usage "Invalid database name"
     [ ${#MYSQL_DATABASE} -le 64 ] || usage "Database name too long (maximum 64 characters)"
   fi
 
   # Specifically check of incomplete specification
-  if [[ -v MYSQL_USER || -v MYSQL_PASSWORD || -v MYSQL_DATABASE ]] && \
+  if [[ ! -z ${MYSQL_USER+x} || ! -z ${MYSQL_PASSWORD+x} || ! -z ${MYSQL_DATABASE+x} ]] && \
      [[ "${user_specified:-0}" == "0" ]]; then
     usage
   fi

--- a/10.1/test/run
+++ b/10.1/test/run
@@ -364,7 +364,7 @@ test_scl_usage() {
 function run_tests() {
   local name=$1 ; shift
   envs="-e MYSQL_USER=$USER -e MYSQL_PASSWORD=$PASS -e MYSQL_DATABASE=db"
-  if [ -v ROOT_PASS ]; then
+  if [ ! -z ${ROOT_PASS+x} ]; then
     envs="$envs -e MYSQL_ROOT_PASSWORD=$ROOT_PASS"
   fi
   create_container $name $envs
@@ -376,7 +376,7 @@ function run_tests() {
   container_ip=$(get_container_ip $name)
   assert_login_access "$container_ip" "$USER" "$PASS" true
   assert_login_access "$container_ip" "$USER" "${PASS}_foo" false
-  if [ -v ROOT_PASS ]; then
+  if [ ! -z ${ROOT_PASS+x} ]; then
     assert_login_access "$container_ip" root "$ROOT_PASS" true
     assert_login_access "$container_ip" root "${ROOT_PASS}_foo" false
   else

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ MariaDB versions currently provided are:
 
 RHEL versions currently supported are:
 * RHEL7
+* RHEL6 (mariadb-10.1 only)
 
 CentOS versions currently supported are:
 * CentOS7
@@ -26,7 +27,7 @@ CentOS versions currently supported are:
 
 Installation
 ----------------------
-Choose either the CentOS7 or RHEL7 based image:
+Choose either the CentOS7, RHEL6, or RHEL7 based image:
 
 *  **RHEL7 based image**
 
@@ -43,6 +44,17 @@ Choose either the CentOS7 or RHEL7 based image:
     $ git clone https://github.com/sclorg/mariadb-container.git
     $ cd mariadb-container
     $ make build TARGET=rhel7 VERSION=10.1
+    ```
+
+*  **RHEL6 based image**
+
+    To build a RHEL6 based MariaDB image, you need to run Docker build on a properly
+    subscribed RHEL machine.
+
+    ```
+    $ git clone https://github.com/sclorg/mariadb-container.git
+    $ cd mariadb-container
+    $ make build TARGET=rhel6 VERSION=10.1
     ```
 
 *  **CentOS7 based image**
@@ -87,7 +99,7 @@ of the MariaDB image.
 
 Users can choose between testing MariaDB based on a RHEL or CentOS image.
 
-*  **RHEL based image**
+*  **RHEL7 based image**
 
     To test a RHEL7 based MariaDB image, you need to run the test on a properly
     subscribed RHEL machine.
@@ -95,6 +107,16 @@ Users can choose between testing MariaDB based on a RHEL or CentOS image.
     ```
     $ cd mariadb-container
     $ make test TARGET=rhel7 VERSION=10.1
+    ```
+
+*  **RHEL6 based image**
+
+    To test a RHEL6 based MariaDB image, you need to run the test on a properly
+    subscribed RHEL machine.
+
+    ```
+    $ cd mariadb-container
+    $ make test TARGET=rhel6 VERSION=10.1
     ```
 
 *  **CentOS based image**

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -82,8 +82,11 @@ for dir in ${dirs}; do
   pushd ${dir} > /dev/null
   if [ "$OS" == "rhel7" -o "$OS" == "rhel7-candidate" ]; then
     docker_build_with_version Dockerfile.rhel7
+  else if [ "$OS" == "rhel6" -o "$OS" == "rhel6-candidate" ]; then
+    docker_build_with_version Dockerfile.rhel6
   else
     docker_build_with_version Dockerfile
+  fi
   fi
 
   if [[ -v TEST_MODE ]]; then

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -4,6 +4,8 @@ build = hack/build.sh
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
+else ifeq ($(TARGET),rhel6)
+	OS := rhel6
 else
 	OS := centos7
 endif


### PR DESCRIPTION
some shell & python script changes required for compatibility w/ all 3 OS builds.

rhel6 only supports mariadb-10.1 so far.