### PR TITLE
Add logic for upgrading datadir

### DIFF
--- a/10.0/root/usr/share/container-scripts/mysql/README.md
+++ b/10.0/root/usr/share/container-scripts/mysql/README.md
@@ -292,19 +292,21 @@ we can control it by setting `MYSQL_UPGRADE` variable, which can have one or mor
    the version file is created if not exist, but no `mysql_upgrade` will be called.
    However, this automatic creation will be removed after few months, since the version should be
    created on most deployments at that point.
- * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
-   can be determined and the data come with the very previous version. A warning is printed if the data
-   come from even older or newer version. This value effectively enables automatic upgrades,
+ * `auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+   daemon is running, but only if the data version can be determined and the data come
+   with the very previous version. A warning is printed if the data come from even older
+   or newer version. This value effectively enables automatic upgrades,
    but it is always risky and users should still back-up all the data before starting the newer container.
    Set this option only if you have very good back-ups at any moment and you are fine to fail-over
    from the back-up.
- * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
-   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
+ * `force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+   daemon is running, no matter what version of the daemon the data come from.
+   This is also the way to create the missing version file `mysql_upgrade_info` if not present
    in the root of the data directory; this file holds information about the version of the data.
- * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
-   of the data is detected. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
-   of the data is detected. It analyzes all the tables.
+ * `optimize` -- runs `mysqlcheck --optimize` at the beginning of the container start, when the local
+   daemon is running, no matter what version of the data is detected. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze` at the beginning of the container start, when the local
+   daemon is running, no matter what version of the data is detected. It analyzes all the tables.
  * `disable` -- nothing is done regarding data directory version.
 
 Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.

--- a/10.0/root/usr/share/container-scripts/mysql/README.md
+++ b/10.0/root/usr/share/container-scripts/mysql/README.md
@@ -284,32 +284,34 @@ faster for large data directory, but only possible if upgrading from the very pr
 so skipping versions is not supported.
 
 This container detects whether the data needs to be upgraded using `mysql_upgrade` and
-we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:
+we can control it by setting `MYSQL_DATADIR_ACTION` variable, which can have one or more of the following values:
 
- * `warn` -- If the data version can be determined and the data come from a different version
+ * `upgrade-warn` -- If the data version can be determined and the data come from a different version
    of the daemon, a warning is printed but the container starts. This is the default value.
    Since historically the version file `mysql_upgrade_info` was not created, when using this option,
    the version file is created if not exist, but no `mysql_upgrade` will be called.
    However, this automatic creation will be removed after few months, since the version should be
    created on most deployments at that point.
- * `auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+ * `upgrade-auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
    daemon is running, but only if the data version can be determined and the data come
    with the very previous version. A warning is printed if the data come from even older
    or newer version. This value effectively enables automatic upgrades,
    but it is always risky and users should still back-up all the data before starting the newer container.
    Set this option only if you have very good back-ups at any moment and you are fine to fail-over
    from the back-up.
- * `force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+ * `upgrade-force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
    daemon is running, no matter what version of the daemon the data come from.
    This is also the way to create the missing version file `mysql_upgrade_info` if not present
    in the root of the data directory; this file holds information about the version of the data.
- * `optimize` -- runs `mysqlcheck --optimize` at the beginning of the container start, when the local
-   daemon is running, no matter what version of the data is detected. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze` at the beginning of the container start, when the local
-   daemon is running, no matter what version of the data is detected. It analyzes all the tables.
+
+There are also some other actions that you may want to run at the beginning of the container start,
+when the local daemon is running, no matter what version of the data is detected:
+
+ * `optimize` -- runs `mysqlcheck --optimize`. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze`. It analyzes all the tables.
  * `disable` -- nothing is done regarding data directory version.
 
-Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_DATADIR_ACTION="optimize,analyze"`.
 
 
 Changing the replication binlog_format

--- a/10.0/root/usr/share/container-scripts/mysql/README.md
+++ b/10.0/root/usr/share/container-scripts/mysql/README.md
@@ -260,6 +260,56 @@ Such a directory `sslapp` can then be mounted into the container with -v,
 or a new container image can be built using s2i.
 
 
+Upgrading and data directory version checking
+---------------------------------------------
+
+MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
+For version changes in Z part, the server's binary data format stays compatible and thus no
+special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
+steps as described at
+https://mariadb.com/kb/en/library/upgrading-from-mariadb-55-to-mariadb-100/
+
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
+the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0.
+
+**Important**: Upgrading to a new version is always risky and users are expected to make a full
+back-up of all data before.
+
+A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
+load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.
+
+Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
+and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
+faster for large data directory, but only possible if upgrading from the very previous version,
+so skipping versions is not supported.
+
+This container detects whether the data needs to be upgraded using `mysql_upgrade` and
+we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:
+
+ * `warn` -- If the data version can be determined and the data come from a different version
+   of the daemon, a warning is printed but the container starts. This is the default value.
+   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
+   the version file is created if not exist, but no `mysql_upgrade` will be called.
+   However, this automatic creation will be removed after few months, since the version should be
+   created on most deployments at that point.
+ * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
+   can be determined and the data come with the very previous version. A warning is printed if the data
+   come from even older or newer version. This value effectively enables automatic upgrades,
+   but it is always risky and users should still back-up all the data before starting the newer container.
+   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
+   from the back-up.
+ * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
+   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
+   in the root of the data directory; this file holds information about the version of the data.
+ * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
+   of the data is detected. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
+   of the data is detected. It analyzes all the tables.
+ * `disable` -- nothing is done regarding data directory version.
+
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
+
+
 Changing the replication binlog_format
 --------------------------------------
 Some applications may wish to use `row` binlog_formats (for example, those built

--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -42,7 +42,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils mariadb-server policycoreutils" && \
+RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils mariadb mariadb-server policycoreutils" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all && \

--- a/10.1/root/usr/share/container-scripts/mysql/README.md
+++ b/10.1/root/usr/share/container-scripts/mysql/README.md
@@ -292,19 +292,21 @@ we can control it by setting `MYSQL_UPGRADE` variable, which can have one or mor
    the version file is created if not exist, but no `mysql_upgrade` will be called.
    However, this automatic creation will be removed after few months, since the version should be
    created on most deployments at that point.
- * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
-   can be determined and the data come with the very previous version. A warning is printed if the data
-   come from even older or newer version. This value effectively enables automatic upgrades,
+ * `auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+   daemon is running, but only if the data version can be determined and the data come
+   with the very previous version. A warning is printed if the data come from even older
+   or newer version. This value effectively enables automatic upgrades,
    but it is always risky and users should still back-up all the data before starting the newer container.
    Set this option only if you have very good back-ups at any moment and you are fine to fail-over
    from the back-up.
- * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
-   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
+ * `force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+   daemon is running, no matter what version of the daemon the data come from.
+   This is also the way to create the missing version file `mysql_upgrade_info` if not present
    in the root of the data directory; this file holds information about the version of the data.
- * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
-   of the data is detected. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
-   of the data is detected. It analyzes all the tables.
+ * `optimize` -- runs `mysqlcheck --optimize` at the beginning of the container start, when the local
+   daemon is running, no matter what version of the data is detected. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze` at the beginning of the container start, when the local
+   daemon is running, no matter what version of the data is detected. It analyzes all the tables.
  * `disable` -- nothing is done regarding data directory version.
 
 Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.

--- a/10.1/root/usr/share/container-scripts/mysql/README.md
+++ b/10.1/root/usr/share/container-scripts/mysql/README.md
@@ -284,32 +284,34 @@ faster for large data directory, but only possible if upgrading from the very pr
 so skipping versions is not supported.
 
 This container detects whether the data needs to be upgraded using `mysql_upgrade` and
-we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:
+we can control it by setting `MYSQL_DATADIR_ACTION` variable, which can have one or more of the following values:
 
- * `warn` -- If the data version can be determined and the data come from a different version
+ * `upgrade-warn` -- If the data version can be determined and the data come from a different version
    of the daemon, a warning is printed but the container starts. This is the default value.
    Since historically the version file `mysql_upgrade_info` was not created, when using this option,
    the version file is created if not exist, but no `mysql_upgrade` will be called.
    However, this automatic creation will be removed after few months, since the version should be
    created on most deployments at that point.
- * `auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+ * `upgrade-auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
    daemon is running, but only if the data version can be determined and the data come
    with the very previous version. A warning is printed if the data come from even older
    or newer version. This value effectively enables automatic upgrades,
    but it is always risky and users should still back-up all the data before starting the newer container.
    Set this option only if you have very good back-ups at any moment and you are fine to fail-over
    from the back-up.
- * `force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+ * `upgrade-force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
    daemon is running, no matter what version of the daemon the data come from.
    This is also the way to create the missing version file `mysql_upgrade_info` if not present
    in the root of the data directory; this file holds information about the version of the data.
- * `optimize` -- runs `mysqlcheck --optimize` at the beginning of the container start, when the local
-   daemon is running, no matter what version of the data is detected. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze` at the beginning of the container start, when the local
-   daemon is running, no matter what version of the data is detected. It analyzes all the tables.
+
+There are also some other actions that you may want to run at the beginning of the container start,
+when the local daemon is running, no matter what version of the data is detected:
+
+ * `optimize` -- runs `mysqlcheck --optimize`. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze`. It analyzes all the tables.
  * `disable` -- nothing is done regarding data directory version.
 
-Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_DATADIR_ACTION="optimize,analyze"`.
 
 
 Changing the replication binlog_format

--- a/10.1/root/usr/share/container-scripts/mysql/README.md
+++ b/10.1/root/usr/share/container-scripts/mysql/README.md
@@ -260,6 +260,56 @@ Such a directory `sslapp` can then be mounted into the container with -v,
 or a new container image can be built using s2i.
 
 
+Upgrading and data directory version checking
+---------------------------------------------
+
+MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
+For version changes in Z part, the server's binary data format stays compatible and thus no
+special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
+steps as described at
+https://mariadb.com/kb/en/library/upgrading-from-mariadb-100-to-mariadb-101/
+
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
+the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0.
+
+**Important**: Upgrading to a new version is always risky and users are expected to make a full
+back-up of all data before.
+
+A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
+load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.
+
+Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
+and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
+faster for large data directory, but only possible if upgrading from the very previous version,
+so skipping versions is not supported.
+
+This container detects whether the data needs to be upgraded using `mysql_upgrade` and
+we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:
+
+ * `warn` -- If the data version can be determined and the data come from a different version
+   of the daemon, a warning is printed but the container starts. This is the default value.
+   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
+   the version file is created if not exist, but no `mysql_upgrade` will be called.
+   However, this automatic creation will be removed after few months, since the version should be
+   created on most deployments at that point.
+ * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
+   can be determined and the data come with the very previous version. A warning is printed if the data
+   come from even older or newer version. This value effectively enables automatic upgrades,
+   but it is always risky and users should still back-up all the data before starting the newer container.
+   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
+   from the back-up.
+ * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
+   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
+   in the root of the data directory; this file holds information about the version of the data.
+ * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
+   of the data is detected. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
+   of the data is detected. It analyzes all the tables.
+ * `disable` -- nothing is done regarding data directory version.
+
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
+
+
 Changing the replication binlog_format
 --------------------------------------
 Some applications may wish to use `row` binlog_formats (for example, those built

--- a/10.2/Dockerfile.fedora
+++ b/10.2/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f26/s2i-core:latest
+FROM registry.fedoraproject.org/f27/s2i-core:latest
 
 # MariaDB image for OpenShift.
 #

--- a/10.2/Dockerfile.fedora
+++ b/10.2/Dockerfile.fedora
@@ -42,7 +42,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils mariadb-server policycoreutils" && \
+RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils mariadb mariadb-server policycoreutils" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all && \

--- a/10.2/root/usr/share/container-scripts/mysql/README.md
+++ b/10.2/root/usr/share/container-scripts/mysql/README.md
@@ -292,19 +292,21 @@ we can control it by setting `MYSQL_UPGRADE` variable, which can have one or mor
    the version file is created if not exist, but no `mysql_upgrade` will be called.
    However, this automatic creation will be removed after few months, since the version should be
    created on most deployments at that point.
- * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
-   can be determined and the data come with the very previous version. A warning is printed if the data
-   come from even older or newer version. This value effectively enables automatic upgrades,
+ * `auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+   daemon is running, but only if the data version can be determined and the data come
+   with the very previous version. A warning is printed if the data come from even older
+   or newer version. This value effectively enables automatic upgrades,
    but it is always risky and users should still back-up all the data before starting the newer container.
    Set this option only if you have very good back-ups at any moment and you are fine to fail-over
    from the back-up.
- * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
-   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
+ * `force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+   daemon is running, no matter what version of the daemon the data come from.
+   This is also the way to create the missing version file `mysql_upgrade_info` if not present
    in the root of the data directory; this file holds information about the version of the data.
- * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
-   of the data is detected. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
-   of the data is detected. It analyzes all the tables.
+ * `optimize` -- runs `mysqlcheck --optimize` at the beginning of the container start, when the local
+   daemon is running, no matter what version of the data is detected. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze` at the beginning of the container start, when the local
+   daemon is running, no matter what version of the data is detected. It analyzes all the tables.
  * `disable` -- nothing is done regarding data directory version.
 
 Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.

--- a/10.2/root/usr/share/container-scripts/mysql/README.md
+++ b/10.2/root/usr/share/container-scripts/mysql/README.md
@@ -284,32 +284,34 @@ faster for large data directory, but only possible if upgrading from the very pr
 so skipping versions is not supported.
 
 This container detects whether the data needs to be upgraded using `mysql_upgrade` and
-we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:
+we can control it by setting `MYSQL_DATADIR_ACTION` variable, which can have one or more of the following values:
 
- * `warn` -- If the data version can be determined and the data come from a different version
+ * `upgrade-warn` -- If the data version can be determined and the data come from a different version
    of the daemon, a warning is printed but the container starts. This is the default value.
    Since historically the version file `mysql_upgrade_info` was not created, when using this option,
    the version file is created if not exist, but no `mysql_upgrade` will be called.
    However, this automatic creation will be removed after few months, since the version should be
    created on most deployments at that point.
- * `auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+ * `upgrade-auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
    daemon is running, but only if the data version can be determined and the data come
    with the very previous version. A warning is printed if the data come from even older
    or newer version. This value effectively enables automatic upgrades,
    but it is always risky and users should still back-up all the data before starting the newer container.
    Set this option only if you have very good back-ups at any moment and you are fine to fail-over
    from the back-up.
- * `force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+ * `upgrade-force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
    daemon is running, no matter what version of the daemon the data come from.
    This is also the way to create the missing version file `mysql_upgrade_info` if not present
    in the root of the data directory; this file holds information about the version of the data.
- * `optimize` -- runs `mysqlcheck --optimize` at the beginning of the container start, when the local
-   daemon is running, no matter what version of the data is detected. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze` at the beginning of the container start, when the local
-   daemon is running, no matter what version of the data is detected. It analyzes all the tables.
+
+There are also some other actions that you may want to run at the beginning of the container start,
+when the local daemon is running, no matter what version of the data is detected:
+
+ * `optimize` -- runs `mysqlcheck --optimize`. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze`. It analyzes all the tables.
  * `disable` -- nothing is done regarding data directory version.
 
-Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_DATADIR_ACTION="optimize,analyze"`.
 
 
 Changing the replication binlog_format

--- a/10.2/root/usr/share/container-scripts/mysql/README.md
+++ b/10.2/root/usr/share/container-scripts/mysql/README.md
@@ -260,6 +260,56 @@ Such a directory `sslapp` can then be mounted into the container with -v,
 or a new container image can be built using s2i.
 
 
+Upgrading and data directory version checking
+---------------------------------------------
+
+MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
+For version changes in Z part, the server's binary data format stays compatible and thus no
+special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
+steps as described at
+https://mariadb.com/kb/en/library/upgrading-from-mariadb-101-to-mariadb-102/
+
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
+the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0.
+
+**Important**: Upgrading to a new version is always risky and users are expected to make a full
+back-up of all data before.
+
+A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
+load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.
+
+Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
+and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
+faster for large data directory, but only possible if upgrading from the very previous version,
+so skipping versions is not supported.
+
+This container detects whether the data needs to be upgraded using `mysql_upgrade` and
+we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:
+
+ * `warn` -- If the data version can be determined and the data come from a different version
+   of the daemon, a warning is printed but the container starts. This is the default value.
+   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
+   the version file is created if not exist, but no `mysql_upgrade` will be called.
+   However, this automatic creation will be removed after few months, since the version should be
+   created on most deployments at that point.
+ * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
+   can be determined and the data come with the very previous version. A warning is printed if the data
+   come from even older or newer version. This value effectively enables automatic upgrades,
+   but it is always risky and users should still back-up all the data before starting the newer container.
+   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
+   from the back-up.
+ * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
+   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
+   in the root of the data directory; this file holds information about the version of the data.
+ * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
+   of the data is detected. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
+   of the data is detected. It analyzes all the tables.
+ * `disable` -- nothing is done regarding data directory version.
+
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
+
+
 Changing the replication binlog_format
 --------------------------------------
 Some applications may wish to use `row` binlog_formats (for example, those built

--- a/root-common/usr/bin/run-mysqld
+++ b/root-common/usr/bin/run-mysqld
@@ -3,6 +3,9 @@
 export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
+if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+  set +e
+fi
 
 export_setting_variables
 

--- a/root-common/usr/bin/run-mysqld-master
+++ b/root-common/usr/bin/run-mysqld-master
@@ -2,9 +2,13 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'master' mode.
 #
+
 export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
+if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+  set +e
+fi
 
 export_setting_variables
 

--- a/root-common/usr/bin/run-mysqld-slave
+++ b/root-common/usr/bin/run-mysqld-slave
@@ -2,9 +2,13 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'slave' mode.
 #
+
 export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
+if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+  set +e
+fi
 
 export_setting_variables
 
@@ -51,6 +55,7 @@ process_extending_files ${APP_DATA}/mysql-init/ ${CONTAINER_SCRIPTS_PATH}/init/
 
 # Restart the MySQL server with public IP bindings
 shutdown_local_mysql
+
 unset_env_vars
 log_volume_info $MYSQL_DATADIR
 log_info 'Running final exec -- Only MySQL server logs after this point'

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -39,7 +39,7 @@ function export_setting_variables() {
     export MYSQL_INNODB_LOG_FILE_SIZE=${MYSQL_INNODB_LOG_FILE_SIZE:-$((MEMORY_LIMIT_IN_BYTES*15/1024/1024/100))M}
     export MYSQL_INNODB_LOG_BUFFER_SIZE=${MYSQL_INNODB_LOG_BUFFER_SIZE:-$((MEMORY_LIMIT_IN_BYTES*15/1024/1024/100))M}
   fi
-  export MYSQL_UPGRADE=${MYSQL_UPGRADE:-warn}
+  export MYSQL_DATADIR_ACTION=${MYSQL_DATADIR_ACTION:-upgrade-warn}
 }
 
 # this stores whether the database was initialized from empty datadir

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -64,9 +64,9 @@ function unset_env_vars() {
 function wait_for_mysql() {
   pid=$1 ; shift
 
-  while [ true ]; do
+  while true; do
     if [ -d "/proc/$pid" ]; then
-      mysqladmin --socket=/tmp/mysql.sock ping &>/dev/null && log_info "MySQL started successfully" && return 0
+      mysqladmin $admin_flags ping &>/dev/null && log_info "MySQL started successfully" && return 0
     else
       return 1
     fi
@@ -103,7 +103,7 @@ function initialize_database() {
   # Running mysql_upgrade creates the mysql_upgrade_info file in the data dir,
   # which is necessary to detect which version of the mysqld daemon created the data.
   # Checking empty file should not take longer than a second and one extra check should not harm.
-  mysql_upgrade --socket=/tmp/mysql.sock
+  mysql_upgrade ${admin_flags}
 
   if [ -v MYSQL_RUNNING_AS_SLAVE ]; then
     log_info 'Initialization finished'

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -39,6 +39,7 @@ function export_setting_variables() {
     export MYSQL_INNODB_LOG_FILE_SIZE=${MYSQL_INNODB_LOG_FILE_SIZE:-$((MEMORY_LIMIT_IN_BYTES*15/1024/1024/100))M}
     export MYSQL_INNODB_LOG_BUFFER_SIZE=${MYSQL_INNODB_LOG_BUFFER_SIZE:-$((MEMORY_LIMIT_IN_BYTES*15/1024/1024/100))M}
   fi
+  export MYSQL_UPGRADE=${MYSQL_UPGRADE:-warn}
 }
 
 # this stores whether the database was initialized from empty datadir
@@ -98,6 +99,11 @@ function initialize_database() {
   # Using empty --basedir to work-around https://bugzilla.redhat.com/show_bug.cgi?id=1406391
   mysql_install_db --rpm --datadir=$MYSQL_DATADIR --basedir=''
   start_local_mysql "$@"
+
+  # Running mysql_upgrade creates the mysql_upgrade_info file in the data dir,
+  # which is necessary to detect which version of the mysqld daemon created the data.
+  # Checking empty file should not take longer than a second and one extra check should not harm.
+  mysql_upgrade --socket=/tmp/mysql.sock
 
   if [ -v MYSQL_RUNNING_AS_SLAVE ]; then
     log_info 'Initialization finished'
@@ -222,4 +228,56 @@ function process_extending_config_files() {
        envsubst < $default_dir/$filename > /etc/my.cnf.d/$filename
     fi
   done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.cnf' | sort -u)"
+}
+
+# Converts string version to the integer format (5.5.33 is converted to 505,
+# 10.1.23-MariaDB is converted into 1001, etc.
+function version2number() {
+  local version_major=$(echo "$1" | grep -o -e '^[0-9]*\.[0-9]*')
+  printf %d%02d ${version_major%%.*} ${version_major##*.}
+}
+
+# Converts the version in format of an integer into major.minor
+function number2version() {
+  local numver=${1}
+  echo $((numver / 100)).$((numver % 100))
+}
+
+# Prints version of the mysqld that is currently available (string)
+function mysqld_version() {
+  ${MYSQL_PREFIX}/libexec/mysqld -V | awk '{print $3}'
+}
+
+# Returns version from the daemon in integer format
+function mysqld_compat_version() {
+  version2number $(mysqld_version)
+}
+
+# Returns version from the datadir
+function get_datadir_version() {
+  local datadir="$1"
+  local upgrade_info_file=$(get_mysql_upgrade_info_file "$datadir")
+  [ -r "$upgrade_info_file" ] || return
+  local version_text=$(cat "$upgrade_info_file" | head -n 1)
+  version2number "${version_text}"
+}
+
+# Returns name of the file in the datadir that holds version information about the data
+function get_mysql_upgrade_info_file() {
+  local datadir="$1"
+  echo "$datadir/mysql_upgrade_info"
+}
+
+# Writes version string of the daemon into mysql_upgrade_info file (should be only used when the file is missing and only when
+function write_mysql_upgrade_info_file() {
+  local datadir="$1"
+  local version=$(mysqld_version)
+  local upgrade_info_file=$(get_mysql_upgrade_info_file "$datadir")
+  if [ -f "$datadir/mysql_upgrade_info" ] ; then
+    echo "File ${upgrade_info_file} exists, nothing is done."
+  else
+    log_info "Storing version '${version}' information into the data dir '${upgrade_info_file}'"
+    echo "${version}" > "${upgrade_info_file}"
+    mysqld_version >"$datadir/mysql_upgrade_info"
+  fi
 }

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -253,7 +253,7 @@ function mysqld_compat_version() {
   version2number $(mysqld_version)
 }
 
-# Returns version from the datadir
+# Returns version from the datadir in the integer format
 function get_datadir_version() {
   local datadir="$1"
   local upgrade_info_file=$(get_mysql_upgrade_info_file "$datadir")
@@ -268,7 +268,10 @@ function get_mysql_upgrade_info_file() {
   echo "$datadir/mysql_upgrade_info"
 }
 
-# Writes version string of the daemon into mysql_upgrade_info file (should be only used when the file is missing and only when
+# Writes version string of the daemon into mysql_upgrade_info file
+# (should be only used when the file is missing and only during limited time;
+# once most deployments include this version file, we should leave it on
+# scripts to generate the file right after initialization or when upgrading)
 function write_mysql_upgrade_info_file() {
   local datadir="$1"
   local version=$(mysqld_version)

--- a/root-common/usr/share/container-scripts/mysql/helpers.sh
+++ b/root-common/usr/share/container-scripts/mysql/helpers.sh
@@ -2,6 +2,10 @@ function log_info {
   echo "---> `date +%T`     $@"
 }
 
+function log_warn {
+  echo "---> `date +%T`     Warning: $@"
+}
+
 function log_and_run {
   log_info "Running $@"
   "$@"

--- a/root-common/usr/share/container-scripts/mysql/helpers.sh
+++ b/root-common/usr/share/container-scripts/mysql/helpers.sh
@@ -25,4 +25,7 @@ function log_volume_info {
     shift
   done
   set -e
+  if [[ -v DEBUG_IGNORE_SCRIPT_FAILURES ]]; then
+    set +e
+  fi
 }

--- a/root-common/usr/share/container-scripts/mysql/init/40-check-upgrade.sh
+++ b/root-common/usr/share/container-scripts/mysql/init/40-check-upgrade.sh
@@ -1,0 +1,111 @@
+upstream_upgrade_info() {
+  echo -n "For upstream documentation about upgrading, see: "
+  case ${MYSQL_VERSION} in
+    10.0) echo "https://mariadb.com/kb/en/library/upgrading-from-mariadb-55-to-mariadb-100/" ;;
+    10.1) echo "https://mariadb.com/kb/en/library/upgrading-from-mariadb-100-to-mariadb-101/" ;;
+    10.2) echo "https://mariadb.com/kb/en/library/upgrading-from-mariadb-101-to-mariadb-102/" ;;
+    5.6) echo "https://dev.mysql.com/doc/refman/5.6/en/upgrading-from-previous-series.html" ;;
+    5.7) echo "https://dev.mysql.com/doc/refman/5.7/en/upgrading-from-previous-series.html" ;;
+    *) echo "Non expected version '${MYSQL_VERSION}'" ; return 1 ;;
+  esac
+}
+
+check_datadir_version() {
+  local datadir="$1"
+  local datadir_version=$(get_datadir_version "$datadir")
+  local mysqld_version=$(mysqld_compat_version)
+  local datadir_version_dot=$(number2version "${datadir_version}")
+  local mysqld_version_dot=$(number2version "${mysqld_version}")
+
+  for upgrade_action in ${MYSQL_UPGRADE//,/ } ; do
+    log_info "Running upgrade action: ${upgrade_action}"
+    case ${upgrade_action} in
+      auto|warn)
+        if [ -z "${datadir_version}" ] || [ "${datadir_version}" -eq 0 ] ; then
+          # Writing the info file, since historically it was not written
+          log_warn "Version of the data could not be determined."\
+                   "It is because the file mysql_upgrade_info is missing in the data directory, which"\
+                   "is most probably because it was not created when initialization of data directory."\
+                   "In order to allow seamless updates to the next higher version in the future,"\
+                   "the file mysql_upgrade_info will be created."\
+                   "If the data directory was created with a different version than ${mysqld_version_dot},"\
+                   "it is required to run this container with the MYSQL_UPGRADE environment variable"\
+                   "set to 'force', or run 'mysql_upgrade' utility manually; the mysql_upgrade tool"\
+                   "checks the tables and creates such a file as well. $(upstream_upgrade_info)"
+          write_mysql_upgrade_info_file "${MYSQL_DATADIR}"
+          continue
+          # This is currently a dead-code, but should be enabled after the mysql_upgrade_info
+          # file gets to the deployments (after few monts most of the deployments should already have the file)
+          log_warn "Version of the data could not be determined."\
+                   "Running such a container is risky."\
+                   "The current daemon version is ${mysqld_version_dot}."\
+                   "If you are not sure whether the data directory is compatible with the current"\
+                   "version ${mysqld_version_dot}, restore the data from a back-up."\
+                   "If restoring from a back-up is not possible, create a file 'mysql_upgrade_info'"\
+                   "that includes version information (${mysqld_version_dot} in this case) in the root"\
+                   "of the data directory."\
+                   "In order to create the 'mysql_upgrade_info' file, either run this container with"\
+                   "the MYSQL_UPGRADE environment variable set to 'force', or run 'mysql_upgrade' utility"\
+                   "manually; the mysql_upgrade tool checks the tables and creates such a file as well."\
+                   "That will enable correct upgrade check in the future. $(upstream_upgrade_info)"
+        fi
+
+        if [ "${datadir_version}" -eq "${mysqld_version}" ] ; then
+          log_info "MySQL server version check passed, both server and data directory"\
+                   "are version ${mysqld_version_dot}."
+          continue
+        fi
+
+        if [ $(( ${datadir_version} + 1 )) -eq "${mysqld_version}" -o "${datadir_version}" -eq 505 -a "${mysqld_version}" -eq 1000 ] ; then
+          log_warn "MySQL server is version ${mysqld_version_dot} and datadir is version"\
+                   "${datadir_version_dot}, which is a compatible combination."
+          if [ "${MYSQL_UPGRADE}" == 'auto' ] ; then
+            log_info "The data directory will be upgraded automatically from ${datadir_version_dot}"\
+                     "to version ${mysqld_version_dot}. $(upstream_upgrade_info)"
+            log_and_run mysql_upgrade --socket=/tmp/mysql.sock
+          else
+            log_warn "Automatic upgrade is not turned on, proceed with the upgrade."\
+                     "In order to upgrade the data directory, run this container with the MYSQL_UPGRADE"\
+                     "environment variable set to 'auto' or run running mysql_upgrade manually. $(upstream_upgrade_info)"
+          fi
+        else
+          log_warn "MySQL server is version ${mysqld_version_dot} and datadir is version"\
+                   "${datadir_version_dot}, which are incompatible. Remember, that upgrade is only supported"\
+                   "by upstream from previous version and it is not allowed to skip versions. $(upstream_upgrade_info)"
+          if [ "${datadir_version}" -gt "${mysqld_version}" ] ; then
+            log_warn "Downgrading to the lower version is not supported. Consider"\
+                     "dumping data and load them again into a fresh instance. $(upstream_upgrade_info)"
+          fi
+          log_warn "Consider restoring the database from a back-up. To ignore this"\
+                   "warning, set 'MYSQL_UPGRADE' variable to 'force', but this may result in data corruption. $(upstream_upgrade_info)"
+          return 1
+        fi
+        ;;
+
+      force)
+        log_and_run mysql_upgrade --socket=/tmp/mysql.sock --force
+        ;;
+
+      optimize)
+        log_and_run mysqlcheck --socket=/tmp/mysql.sock --optimize --all-databases --force
+        ;;
+
+      analyze)
+        log_and_run mysqlcheck --socket=/tmp/mysql.sock --analyze --all-databases --force
+        ;;
+
+      disable)
+        log_info "Nothing is done about the data directory version."
+        ;;
+      *)
+        log_warn "Unknown value of MYSQL_UPGRADE variable: '${MYSQL_UPGRADE}', ignoring."
+        ;;
+    esac
+  done
+}
+
+check_datadir_version "${MYSQL_DATADIR}"
+
+unset -f check_datadir_version upstream_upgrade_info
+
+

--- a/root-common/usr/share/container-scripts/mysql/init/40-check-upgrade.sh
+++ b/root-common/usr/share/container-scripts/mysql/init/40-check-upgrade.sh
@@ -35,7 +35,7 @@ check_datadir_version() {
           write_mysql_upgrade_info_file "${MYSQL_DATADIR}"
           continue
           # This is currently a dead-code, but should be enabled after the mysql_upgrade_info
-          # file gets to the deployments (after few monts most of the deployments should already have the file)
+          # file gets to the deployments (after few months most of the deployments should already have the file)
           log_warn "Version of the data could not be determined."\
                    "Running such a container is risky."\
                    "The current daemon version is ${mysqld_version_dot}."\
@@ -62,11 +62,11 @@ check_datadir_version() {
           if [ "${MYSQL_UPGRADE}" == 'auto' ] ; then
             log_info "The data directory will be upgraded automatically from ${datadir_version_dot}"\
                      "to version ${mysqld_version_dot}. $(upstream_upgrade_info)"
-            log_and_run mysql_upgrade --socket=/tmp/mysql.sock
+            log_and_run mysql_upgrade ${mysql_flags}
           else
             log_warn "Automatic upgrade is not turned on, proceed with the upgrade."\
                      "In order to upgrade the data directory, run this container with the MYSQL_UPGRADE"\
-                     "environment variable set to 'auto' or run running mysql_upgrade manually. $(upstream_upgrade_info)"
+                     "environment variable set to 'auto' or run mysql_upgrade manually. $(upstream_upgrade_info)"
           fi
         else
           log_warn "MySQL server is version ${mysqld_version_dot} and datadir is version"\
@@ -83,15 +83,15 @@ check_datadir_version() {
         ;;
 
       force)
-        log_and_run mysql_upgrade --socket=/tmp/mysql.sock --force
+        log_and_run mysql_upgrade ${mysql_flags} --force
         ;;
 
       optimize)
-        log_and_run mysqlcheck --socket=/tmp/mysql.sock --optimize --all-databases --force
+        log_and_run mysqlcheck ${mysql_flags} --optimize --all-databases --force
         ;;
 
       analyze)
-        log_and_run mysqlcheck --socket=/tmp/mysql.sock --analyze --all-databases --force
+        log_and_run mysqlcheck ${mysql_flags} --analyze --all-databases --force
         ;;
 
       disable)

--- a/root-common/usr/share/container-scripts/mysql/pre-init/20-validate-variables.sh
+++ b/root-common/usr/share/container-scripts/mysql/pre-init/20-validate-variables.sh
@@ -76,7 +76,6 @@ function validate_variables() {
   fi
 }
 
-
 if ! [ -v MYSQL_RUNNING_AS_SLAVE ] ; then
   validate_variables
 fi

--- a/test/run
+++ b/test/run
@@ -608,7 +608,6 @@ function run_upgrade_test() {
   # Create version file that we cannot upgrade from
   echo "  Testing upgrade from the future version"
   echo "20.1.12" >${datadir}/mysql_upgrade_info
-  # Create another container with same data and upgrade set to 'optimize'
   assert_container_creation_fails -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
     -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto 2>/dev/null
 

--- a/test/run
+++ b/test/run
@@ -548,16 +548,16 @@ function run_upgrade_test() {
   # Create version file that is too old
   echo "  Testing upgrade from too old data"
   echo "5.0.12" >${datadir}/mysql_upgrade_info
-  # Create another container with same data and upgrade set to 'auto'
+  # Create another container with same data and upgrade set to 'upgrade-auto'
   assert_container_creation_fails -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
-    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto 2>/dev/null
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_DATADIR_ACTION=upgrade-auto 2>/dev/null
 
   # Create version file that we can upgrade from
   echo "  Testing upgrade from previous version"
   echo "$(get_previous_major_version ${VERSION}).12" >${datadir}/mysql_upgrade_info
-  # Create another container with same data and upgrade set to 'auto'
+  # Create another container with same data and upgrade set to 'upgrade-aauto'
   create_container "testupg3" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
-    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_DATADIR_ACTION=upgrade-auto
   test_connection testupg3 user foo
   docker stop $(ct_get_cid testupg3) >/dev/null
   # Check whether some upgrade happened
@@ -570,9 +570,9 @@ function run_upgrade_test() {
   # Create version file that we don't need to upgrade from
   echo "  Testing upgrade from the same version"
   echo "${VERSION}.12" >${datadir}/mysql_upgrade_info
-  # Create another container with same data and upgrade set to 'auto'
+  # Create another container with same data and upgrade set to 'upgrade-aauto'
   create_container "testupg4" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
-    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_DATADIR_ACTION=upgrade-auto
   test_connection testupg4 user foo
   docker stop $(ct_get_cid testupg4) >/dev/null
   # Check whether some upgrade happened
@@ -584,7 +584,7 @@ function run_upgrade_test() {
   # Create second container with same data and upgrade set to 'analyze'
   echo "  Testing running --analyze"
   create_container "testupg5" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
-    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=analyze
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_DATADIR_ACTION=analyze
   test_connection testupg5 user foo
   docker stop $(ct_get_cid testupg5) >/dev/null
   # Check whether analyze happened
@@ -596,7 +596,7 @@ function run_upgrade_test() {
   # Create another container with same data and upgrade set to 'optimize'
   echo "  Testing running --optimize"
   create_container "testupg6" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
-    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=optimize
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_DATADIR_ACTION=optimize
   test_connection testupg6 user foo
   docker stop $(ct_get_cid testupg6) >/dev/null
   # Check whether optimize happened
@@ -609,7 +609,7 @@ function run_upgrade_test() {
   echo "  Testing upgrade from the future version"
   echo "20.1.12" >${datadir}/mysql_upgrade_info
   assert_container_creation_fails -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
-    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto 2>/dev/null
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_DATADIR_ACTION=upgrade-auto 2>/dev/null
 
   echo "  Upgrade tests succeeded!"
   echo

--- a/test/run
+++ b/test/run
@@ -22,6 +22,7 @@ run_replication_test
 run_doc_test
 run_s2i_test
 run_ssl_test
+run_upgrade_test
 "
 
 if [ -e "${IMAGE_NAME:-}" ] ; then
@@ -50,7 +51,7 @@ function mysql_cmd() {
   local container_ip="$1"; shift
   local login="$1"; shift
   local password="$1"; shift
-  docker run --rm "$IMAGE_NAME" mysql --host "$container_ip" -u"$login" -p"$password" "$@" db
+  docker run --rm ${CONTAINER_EXTRA_ARGS:-} "$IMAGE_NAME" mysql --host "$container_ip" -u"$login" -p"$password" "$@" db
 }
 
 function test_connection() {
@@ -63,15 +64,30 @@ function test_connection() {
   local max_attempts=20
   local sleep_time=2
   local i
+  local status=''
+  echo -n "    Trying to connect..."
   for i in $(seq $max_attempts); do
-    echo "    Trying to connect..."
-    if mysql_cmd "$ip" "$login" "$password" <<< 'SELECT 1;'; then
+    local status=$(docker inspect -f '{{.State.Status}}' $(ct_get_cid "${name}"))
+    if [ "${status}" != 'running' ] ; then
+      break;
+    fi
+    echo -n "."
+    if mysql_cmd "$ip" "$login" "$password" &>/dev/null <<< 'SELECT 1;'; then
+      echo " OK"
       echo "  Success!"
       return 0
     fi
     sleep $sleep_time
   done
-  echo "  Giving up: Failed to connect. Logs:"
+  echo " FAIL"
+  echo "  Giving up: Failed to connect."
+  if [ "${status}" == 'running' ] ; then
+    echo "  Container is still running."
+  else
+    local exit_status=$(docker inspect -f '{{.State.ExitCode}}' ${name})
+    echo "  Container finised with exit code ${exit_status}."
+  fi
+  echo "Logs:"
   docker logs $(ct_get_cid $name)
   return 1
 }
@@ -97,7 +113,7 @@ function create_container() {
   # create container with a cidfile in a directory for cleanup
   local container_id
   container_id="$(docker run ${DOCKER_ARGS:-} --cidfile $cidfile -d "$@" $IMAGE_NAME ${CONTAINER_ARGS:-})"
-  echo "Created container $container_id"
+  echo "    Created container $container_id"
 }
 
 function run_change_password_test() {
@@ -223,6 +239,7 @@ function assert_container_creation_fails() {
   if [ $ret -gt 30 ]; then
     return 1
   fi
+  echo "  Success!"
 }
 
 function try_image_invalid_combinations() {
@@ -395,9 +412,9 @@ run_doc_test() {
 _s2i_test_image() {
   local container_name="$1"
   local mount_opts="$2"
-  echo "    Testing s2i app image with invalid configuration"
+  echo "  Testing s2i app image with invalid configuration"
   assert_container_creation_fails -e MYSQL_USER=root -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -e MYSQL_ROOT_PASSWORD=pass
-  echo "    Testing s2i app image with correct configuration"
+  echo "  Testing s2i app image with correct configuration"
   create_container \
     "$container_name" \
     --env MYSQL_USER=config_test_user \
@@ -456,6 +473,7 @@ ssl-key=\${APP_DATA}/mysql-certs/server-key.pem
 ssl-cert=\${APP_DATA}/mysql-certs/server-cert-selfsigned.pem
 " >${test_app_dir}/mysql-cfg/ssl.cnf
   chown -R 27:27 ${test_app_dir}
+  local ca_cert_path="/opt/app-root/src/mysql-certs/server-cert-selfsigned.pem"
 
   create_container \
     "_s2i_test_ssl" \
@@ -466,12 +484,15 @@ ssl-cert=\${APP_DATA}/mysql-certs/server-cert-selfsigned.pem
 
   test_connection "_s2i_test_ssl" ssl_test_user ssl_test
   ip=$(ct_get_cip _s2i_test_ssl)
-  if mysql_cmd "$ip" "ssl_test_user" "ssl_test" --ssl -e 'show status like "Ssl_cipher" \G' | grep 'Value: [A-Z][A-Z0-9-]*' ; then
+
+  # At least MySQL 5.6 requires ssl-ca option on client side, otherwise the ssl is not used
+  CONTAINER_EXTRA_ARGS="-v ${test_app_dir}:/opt/app-root/src/:z"
+  if mysql_cmd "$ip" "ssl_test_user" "ssl_test" --ssl-mode=REQUIRED --ssl-ca=${ca_cert_path} -e 'show status like "Ssl_cipher" \G' | grep 'Value: [A-Z][A-Z0-9-]*' ; then
     echo "  Success!"
     rm -rf ${test_app_dir}
   else
     echo "  FAIL!"
-    mysql_cmd "$ip" "ssl_test_user" "ssl_test" --ssl -e 'status \G'
+    mysql_cmd "$ip" "ssl_test_user" "ssl_test" --ssl-ca=${ca_cert_path} -e 'show status like "%ssl%" \G'
     return 1
   fi
 }
@@ -486,6 +507,122 @@ function run_general_tests() {
   # Test with arbitrary uid for the container
   DOCKER_ARGS="-u 12345" USER=user PASS=pass run_tests no_root_altuid
   DOCKER_ARGS="-u 12345" USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root_altuid
+}
+
+function get_previous_major_version() {
+  case "${1}" in
+    5.5) echo "5.1" ;;
+    5.6) echo "5.5" ;;
+    5.7) echo "5.6" ;;
+    8.0) echo "5.7" ;;
+    10.0) echo "5.5" ;;
+    10.1) echo "10.0" ;;
+    10.2) echo "10.1" ;;
+    10.3) echo "10.2" ;;
+    *) echo "Non expected version '${1}'" ; return 1 ;;
+  esac
+}
+
+function run_upgrade_test() {
+  local tmpdir=$(mktemp -d)
+  echo "  Testing upgrade of the container image"
+  mkdir "${tmpdir}/data" && chmod -R a+rwx "${tmpdir}"
+
+  # Create MySQL container with persistent volume and set the version from too old version
+  local datadir=${tmpdir}
+  create_container "testupg1" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z
+  test_connection testupg1 user foo
+  docker stop $(ct_get_cid testupg1) >/dev/null
+
+  # Simulate datadir without version information
+  rm -f ${datadir}/mysql_upgrade_info
+  echo "  Testing upgrade from data without version"
+  # This should work, but warning should be printed
+  create_container "testupg2" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z
+  test_connection testupg2 user foo
+  docker stop $(ct_get_cid testupg2) >/dev/null
+  # Check whether some information is provided
+  if ! docker logs $(ct_get_cid testupg2) 2>&1 | grep -e 'Version of the data could not be determined' &>/dev/null ; then
+    echo "Information about missing version file is not available in the logs"
+    return 1
+  fi
+  # Check whether upgrade did not happen
+  if docker logs $(ct_get_cid testupg2) 2>&1 | grep -e 'Running mysql_upgrade --socket=/tmp/mysql.sock' &>/dev/null ; then
+    echo "Upgrade should not be run when information about version is missing"
+    return 1
+  fi
+
+  # Create version file that is too old
+  echo "  Testing upgrade from too old data"
+  echo "5.0.12" >${datadir}/mysql_upgrade_info
+  # Create another container with same data and upgrade set to 'auto'
+  assert_container_creation_fails -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto 2>/dev/null
+
+  # Create version file that we can upgrade from
+  echo "  Testing upgrade from previous version"
+  echo "$(get_previous_major_version ${VERSION}).12" >${datadir}/mysql_upgrade_info
+  # Create another container with same data and upgrade set to 'auto'
+  create_container "testupg3" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto
+  test_connection testupg3 user foo
+  docker stop $(ct_get_cid testupg3) >/dev/null
+  # Check whether some upgrade happened
+  if ! docker logs $(ct_get_cid testupg3) 2>&1 | grep -e 'Running mysql_upgrade --socket=/tmp/mysql.sock' &>/dev/null ; then
+    echo "Upgrade did not happen but it should when upgrading from previous version"
+    docker logs $(ct_get_cid testupg3)
+    return 1
+  fi
+
+  # Create version file that we don't need to upgrade from
+  echo "  Testing upgrade from the same version"
+  echo "${VERSION}.12" >${datadir}/mysql_upgrade_info
+  # Create another container with same data and upgrade set to 'auto'
+  create_container "testupg4" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto
+  test_connection testupg4 user foo
+  docker stop $(ct_get_cid testupg4) >/dev/null
+  # Check whether some upgrade happened
+  if docker logs $(ct_get_cid testupg4) 2>&1 | grep -e 'Running mysql_upgrade --socket=/tmp/mysql.sock' &>/dev/null ; then
+    echo "Upgrade happened but it should not when upgrading from current version"
+    return 1
+  fi
+
+  # Create second container with same data and upgrade set to 'analyze'
+  echo "  Testing running --analyze"
+  create_container "testupg5" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=analyze
+  test_connection testupg5 user foo
+  docker stop $(ct_get_cid testupg5) >/dev/null
+  # Check whether analyze happened
+  if ! docker logs $(ct_get_cid testupg5) 2>&1 | grep -e '--analyze --all-databases' &>/dev/null ; then
+    echo "Analyze did not happen but it should"
+    return 1
+  fi
+
+  # Create another container with same data and upgrade set to 'optimize'
+  echo "  Testing running --optimize"
+  create_container "testupg6" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=optimize
+  test_connection testupg6 user foo
+  docker stop $(ct_get_cid testupg6) >/dev/null
+  # Check whether optimize happened
+  if ! docker logs $(ct_get_cid testupg6) 2>&1 | grep -e '--optimize --all-databases' &>/dev/null ; then
+    echo "Optimize did not happen but it should"
+    return 1
+  fi
+
+  # Create version file that we cannot upgrade from
+  echo "  Testing upgrade from the future version"
+  echo "20.1.12" >${datadir}/mysql_upgrade_info
+  # Create another container with same data and upgrade set to 'optimize'
+  assert_container_creation_fails -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z -e MYSQL_UPGRADE=auto 2>/dev/null
+
+  echo "  Upgrade tests succeeded!"
+  echo
 }
 
 function run_all_tests() {

--- a/test/run
+++ b/test/run
@@ -40,9 +40,9 @@ function cleanup() {
   ct_cleanup
 
   if [ $TESTSUITE_RESULT -eq 0 ] ; then
-    echo "Tests succeeded."
+    echo "Tests for ${IMAGE_NAME} succeeded."
   else
-    echo "Tests failed."
+    echo "Tests for ${IMAGE_NAME} failed."
   fi
 }
 trap cleanup EXIT SIGINT
@@ -388,23 +388,8 @@ function run_tests() {
 }
 
 run_doc_test() {
-  local tmpdir=$(mktemp -d)
-  local f
   echo "  Testing documentation in the container image"
-  # Extract the help.1 file from the container
-  docker run --rm ${IMAGE_NAME} /bin/bash -c "cat /help.1" >${tmpdir}/help.1
-  # Check whether the help.1 file includes some important information
-  for term in "MYSQL\_ROOT\_PASSWORD" volume 3306 ; do
-    if ! cat ${tmpdir}/help.1 | grep -F -q -e "${term}" ; then
-      echo "ERROR: File /help.1 does not include '${term}'."
-      return 1
-    fi
-  done
-  # Check whether the file uses the correct format
-  if ! file ${tmpdir}/help.1 | grep -q roff ; then
-    echo "ERROR: /help.1 is not in troff or groff format"
-    return 1
-  fi
+  ct_doc_content_old "MYSQL\_ROOT\_PASSWORD" volume 3306
   echo "  Success!"
   echo
 }
@@ -487,7 +472,13 @@ ssl-cert=\${APP_DATA}/mysql-certs/server-cert-selfsigned.pem
 
   # At least MySQL 5.6 requires ssl-ca option on client side, otherwise the ssl is not used
   CONTAINER_EXTRA_ARGS="-v ${test_app_dir}:/opt/app-root/src/:z"
-  if mysql_cmd "$ip" "ssl_test_user" "ssl_test" --ssl-mode=REQUIRED --ssl-ca=${ca_cert_path} -e 'show status like "Ssl_cipher" \G' | grep 'Value: [A-Z][A-Z0-9-]*' ; then
+
+  # MySQL requires --ssl-mode to be set in order to require SSL
+  case ${VERSION} in
+    5*) ssl_mode_opt='--ssl-mode=REQUIRED'
+  esac
+
+  if mysql_cmd "$ip" "ssl_test_user" "ssl_test" ${ssl_mode_opt:-} --ssl-ca=${ca_cert_path} -e 'show status like "Ssl_cipher" \G' | grep 'Value: [A-Z][A-Z0-9-]*' ; then
     echo "  Success!"
     rm -rf ${test_app_dir}
   else
@@ -529,7 +520,7 @@ function run_upgrade_test() {
   mkdir "${tmpdir}/data" && chmod -R a+rwx "${tmpdir}"
 
   # Create MySQL container with persistent volume and set the version from too old version
-  local datadir=${tmpdir}
+  local datadir=${tmpdir}/data
   create_container "testupg1" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
     -e MYSQL_DATABASE=db -v ${datadir}:/var/lib/mysql/data:Z
   test_connection testupg1 user foo
@@ -549,7 +540,7 @@ function run_upgrade_test() {
     return 1
   fi
   # Check whether upgrade did not happen
-  if docker logs $(ct_get_cid testupg2) 2>&1 | grep -e 'Running mysql_upgrade --socket=/tmp/mysql.sock' &>/dev/null ; then
+  if docker logs $(ct_get_cid testupg2) 2>&1 | grep -e 'Running mysql_upgrade' &>/dev/null ; then
     echo "Upgrade should not be run when information about version is missing"
     return 1
   fi
@@ -570,7 +561,7 @@ function run_upgrade_test() {
   test_connection testupg3 user foo
   docker stop $(ct_get_cid testupg3) >/dev/null
   # Check whether some upgrade happened
-  if ! docker logs $(ct_get_cid testupg3) 2>&1 | grep -e 'Running mysql_upgrade --socket=/tmp/mysql.sock' &>/dev/null ; then
+  if ! docker logs $(ct_get_cid testupg3) 2>&1 | grep -qe 'Running mysql_upgrade' ; then
     echo "Upgrade did not happen but it should when upgrading from previous version"
     docker logs $(ct_get_cid testupg3)
     return 1
@@ -585,7 +576,7 @@ function run_upgrade_test() {
   test_connection testupg4 user foo
   docker stop $(ct_get_cid testupg4) >/dev/null
   # Check whether some upgrade happened
-  if docker logs $(ct_get_cid testupg4) 2>&1 | grep -e 'Running mysql_upgrade --socket=/tmp/mysql.sock' &>/dev/null ; then
+  if docker logs $(ct_get_cid testupg4) 2>&1 | grep -e 'Running mysql_upgrade' &>/dev/null ; then
     echo "Upgrade happened but it should not when upgrading from current version"
     return 1
   fi
@@ -627,7 +618,7 @@ function run_upgrade_test() {
 
 function run_all_tests() {
   for test_case in $TEST_LIST; do
-    : "Running test $test_case"
+    echo "Running test $test_case for ${IMAGE_NAME}"
     $test_case
   done;
 }


### PR DESCRIPTION
MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
For version changes in Z part, the server's binary data format stays compatible and thus no
special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
steps as described at
https://mariadb.com/kb/en/library/upgrading-from-mariadb-101-to-mariadb-102/

Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0.

**Important**: Upgrading to a new version is always risky and users are expected to make a full
back-up of all data before.

A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.

Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
faster for large data directory, but only possible if upgrading from the very previous version,
so skipping versions is not supported.

This container detects whether the data needs to be upgraded using `mysql_upgrade` and
we can control it by setting `MYSQL_UPGRADE` variable, which can have one or more of the following values:

 * `warn` -- If the data version can be determined and the data come from a different version
   of the daemon, a warning is printed but the container starts. This is the default value.
   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
   the version file is created if not exist, but no `mysql_upgrade` will be called.
   However, this automatic creation will be removed after few months, since the version should be
   created on most deployments at that point.
 * `auto` -- `mysql_upgrade` is run at the beginning of the container start, if the data version
   can be determined and the data come with the very previous version. A warning is printed if the data
   come from even older or newer version. This value effectively enables automatic upgrades,
   but it is always risky and users should still back-up all the data before starting the newer container.
   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
   from the back-up.
 * `force` -- `mysql_upgrade` is run right after the daemon has started, no matter what version the data
   come from. This is also the way to create the missing version file `mysql_upgrade_info` if not present
   in the root of the data directory; this file holds information about the version of the data.
 * `optimize` -- runs `mysqlcheck --optimize` before starting the mysqld daemon, no matter what version
   of the data is detected. It optimizes all the tables.
 * `analyze` -- runs `mysqlcheck --analyze` before starting the mysqld daemon, no matter what version
   of the data is detected. It analyzes all the tables.
 * `disable` -- nothing is done regarding data directory version.

Multiple values are separated by comma and run in-order, e.g. `MYSQL_UPGRADE="optimize,analyze"`.
