### PR TITLE
Update Dockerfiles

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -51,7 +51,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -24,7 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MariaDB 10.0" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mariadb,mariadb100,rh-mariadb100"
+      io.openshift.tags="database,mysql,mariadb,mariadb100,rh-mariadb100" \
+      com.redhat.component="rh-mariadb100-docker" \
+      name="centos/mariadb-100-centos7" \
+      version="10.0" \
+      release="1"
 
 EXPOSE 3306
 

--- a/10.0/Dockerfile.rhel7
+++ b/10.0/Dockerfile.rhel7
@@ -60,7 +60,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.0/Dockerfile.rhel7
+++ b/10.0/Dockerfile.rhel7
@@ -24,14 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MariaDB 10.0" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mariadb,mariadb100,rh-mariadb100"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-mariadb100-docker" \
+      io.openshift.tags="database,mysql,mariadb,mariadb100,rh-mariadb100" \
+      com.redhat.component="rh-mariadb100-docker" \
       name="rhscl/mariadb-100-rhel7" \
       version="10.0" \
-      release="13.3" \
-      architecture="x86_64"
+      release="13.3"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -51,7 +51,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -24,7 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MariaDB 10.1" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mariadb,mariadb101,rh-mariadb101,galera"
+      io.openshift.tags="database,mysql,mariadb,mariadb101,rh-mariadb101,galera" \
+      com.redhat.component="rh-mariadb101-docker" \
+      name="centos/mariadb-101-centos7" \
+      version="10.1" \
+      release="1"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -48,7 +48,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -13,18 +13,22 @@ MAINTAINER "Honza Horak" <hhorak@redhat.com>
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.1 \
-    HOME=/var/lib/mysql
+    HOME=/var/lib/mysql \
+    NAME=mariadb \
+    VERSION=10.1 \
+    RELEASE=1 \
+    ARCH=x86_64
 
 LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
       io.k8s.description="MariaDB is a multi-user, multi-threaded SQL database server" \
       io.k8s.display-name="MariaDB 10.1" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb101,galera" \
-      BZComponent="$NAME" \
-      Name="$FGC/$NAME" \
-      Version="$VERSION" \
-      Release="$RELEASE.$DISTTAG" \
-      Architecture="$ARCH"
+      com.redhat.component="$NAME" \
+      name="$FGC/$NAME" \
+      version="$VERSION" \
+      release="$RELEASE.$DISTTAG" \
+      architecture="$ARCH"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -19,14 +19,12 @@ LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
       io.k8s.description="MariaDB is a multi-user, multi-threaded SQL database server" \
       io.k8s.display-name="MariaDB 10.1" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mariadb,mariadb101,galera"
-
-ENV NAME=mariadb VERSION=10.1 RELEASE=1 ARCH=x86_64
-LABEL BZComponent="$NAME" \
-        Name="$FGC/$NAME" \
-        Version="$VERSION" \
-        Release="$RELEASE.$DISTTAG" \
-        Architecture="$ARCH"
+      io.openshift.tags="database,mysql,mariadb,mariadb101,galera" \
+      BZComponent="$NAME" \
+      Name="$FGC/$NAME" \
+      Version="$VERSION" \
+      Release="$RELEASE.$DISTTAG" \
+      Architecture="$ARCH"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -60,7 +60,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-ADD root /
+COPY root /
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -24,14 +24,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="MariaDB 10.1" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,mariadb,mariadb101,rh-mariadb101"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-mariadb101-docker" \
+      io.openshift.tags="database,mysql,mariadb,mariadb101,rh-mariadb101" \
+      com.redhat.component="rh-mariadb101-docker" \
       name="rhscl/mariadb-101-rhel7" \
       version="10.1" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 EXPOSE 3306
 


### PR DESCRIPTION
 Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)

Provide same labels for all base image variants (CentOS, RHEL, Fedora)
    - add name and version labels
    - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
 
(don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.