### PR TITLE
Load ini SQL files from /docker-entrypoint-initdb.d if any (for 10.1 in a first time)

### DIFF
--- a/10.1/root/usr/share/container-scripts/mysql/common.sh
+++ b/10.1/root/usr/share/container-scripts/mysql/common.sh
@@ -131,6 +131,17 @@ mysql $mysql_flags <<EOSQL
       GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
       FLUSH PRIVILEGES ;
 EOSQL
+
+echo
+echo 'Handling files in /docker-entrypoint-initdb.d if any... '
+for f in /docker-entrypoint-initdb.d/*; do
+	case "$f" in
+		*.sql)    echo "running $f"; mysql $mysql_flags ${MYSQL_DATABASE} < "$f"; echo ;;
+		*)        echo "ignoring $f" ;;
+	esac
+	echo
+done
+
     fi
   fi
 


### PR DESCRIPTION
This change adds the possibility to provide ini SQL files in /docker-entrypoint-initdb.d (only for 10.1 in a first time). This is really useful to provide images with an initial state for a test or QA environment.

The patch is deeply inspired from the official mysql docker image. Supporting exactly the same startup features would be really great. See "Initializing a fresh instance" in https://hub.docker.com/_/mysql/
or here for the sources
https://github.com/docker-library/mysql/blame/dc60c4b80f3eb5b7ef8b9ae09f16f6fab7a2fbf5/8.0/docker-entrypoint.sh#L177

This is similar to my pull request for mysql-container: https://github.com/sclorg/mysql-container/pull/185

<!-- issue-commentator = {"comment-id":"2457551952"} -->