### PR TITLE
Do not set innodb_additional_mem_pool_size which is deprecated

### DIFF
--- a/10.0/Dockerfile.rhel7
+++ b/10.0/Dockerfile.rhel7
@@ -35,9 +35,14 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils gettext hostname && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
+    yum-config-manager --disable * &> /dev/null && \
+    yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="rsync tar gettext hostname bind-utils rh-mariadb100" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/10.0/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
+++ b/10.0/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
@@ -11,7 +11,6 @@ myisam_sort_buffer_size = 2M
 
 # It is recommended that innodb_buffer_pool_size is configured to 50 to 75 percent of system memory.
 innodb_buffer_pool_size = ${MYSQL_INNODB_BUFFER_POOL_SIZE}
-innodb_additional_mem_pool_size = 2M
 # Set .._log_file_size to 25 % of buffer pool size
 innodb_log_file_size = ${MYSQL_INNODB_LOG_FILE_SIZE}
 innodb_log_buffer_size = ${MYSQL_INNODB_LOG_BUFFER_SIZE}

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -35,9 +35,14 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum install -y yum-utils gettext hostname && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils && \
+    yum-config-manager --disable * &> /dev/null && \
+    yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="rsync tar gettext hostname bind-utils rh-mariadb101" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/10.1/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
+++ b/10.1/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
@@ -11,7 +11,6 @@ myisam_sort_buffer_size = 2M
 
 # It is recommended that innodb_buffer_pool_size is configured to 50 to 75 percent of system memory.
 innodb_buffer_pool_size = ${MYSQL_INNODB_BUFFER_POOL_SIZE}
-innodb_additional_mem_pool_size = 2M
 # Set .._log_file_size to 25 % of buffer pool size
 innodb_log_file_size = ${MYSQL_INNODB_LOG_FILE_SIZE}
 innodb_log_buffer_size = ${MYSQL_INNODB_LOG_BUFFER_SIZE}


### PR DESCRIPTION
Do not set `innodb_additional_mem_pool_size` server option which is deprecated and also not used unless `innodb_use_sys_malloc` is turned off, which is not.
See more at https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_additional_mem_pool_size