### PR TITLE
add usage and description labels

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -12,9 +12,8 @@ FROM centos/s2i-core-centos7
 
 ENV MYSQL_VERSION=10.0 \
     APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql
-
-ENV SUMMARY="MariaDB 10.0 SQL database server" \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.0 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,7 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb100-docker" \
       name="centos/mariadb-100-centos7" \
       version="10.0" \
-      release="1"
+      release="1" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 centos/mariadb-100-centos7"
 
 EXPOSE 3306
 

--- a/10.0/Dockerfile.rhel7
+++ b/10.0/Dockerfile.rhel7
@@ -12,9 +12,8 @@ FROM rhscl/s2i-core-rhel7
 
 ENV MYSQL_VERSION=10.0 \
     APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql
-
-ENV SUMMARY="MariaDB 10.0 SQL database server" \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.0 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,7 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb100-docker" \
       name="rhscl/mariadb-100-rhel7" \
       version="10.0" \
-      release="13.3"
+      release="13.3" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 registry.access.redhat.com/rhscl/mariadb-100-rhel7"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -12,9 +12,8 @@ FROM centos/s2i-core-centos7
 
 ENV MYSQL_VERSION=10.1 \
     APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql
-
-ENV SUMMARY="MariaDB 10.1 SQL database server" \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.1 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,7 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb101-docker" \
       name="centos/mariadb-101-centos7" \
       version="10.1" \
-      release="1"
+      release="1" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 centos/mariadb-101-centos7"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -16,9 +16,15 @@ ENV MYSQL_VERSION=10.1 \
     NAME=mariadb \
     VERSION=10.1 \
     RELEASE=1 \
-    ARCH=x86_64
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.1 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
       io.k8s.description="MariaDB is a multi-user, multi-threaded SQL database server" \
       io.k8s.display-name="MariaDB 10.1" \
       io.openshift.expose-services="3306:mysql" \
@@ -28,7 +34,8 @@ LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
-      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 $FGC/$NAME"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -12,9 +12,8 @@ FROM rhscl/s2i-core-rhel7
 
 ENV MYSQL_VERSION=10.1 \
     APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql
-
-ENV SUMMARY="MariaDB 10.1 SQL database server" \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.1 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,7 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb101-docker" \
       name="rhscl/mariadb-101-rhel7" \
       version="10.1" \
-      release="1"
+      release="1" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 registry.access.redhat.com/rhscl/mariadb-101-rhel7"
 
 EXPOSE 3306
 

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -12,9 +12,8 @@ FROM centos/s2i-core-centos7
 
 ENV MYSQL_VERSION=10.2 \
     APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql
-
-ENV SUMMARY="MariaDB 10.2 SQL database server" \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.2 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -28,7 +27,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102,galera" \
       com.redhat.component="rh-mariadb102-docker" \
       name="centos/mariadb-102-centos7" \
-      version="1"
+      version="1" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 centos/mariadb-102-centos7"
 
 EXPOSE 3306
 

--- a/10.2/Dockerfile.fedora
+++ b/10.2/Dockerfile.fedora
@@ -16,9 +16,15 @@ ENV MYSQL_VERSION=10.2 \
     NAME=mariadb \
     VERSION=10.2 \
     RELEASE=1 \
-    ARCH=x86_64
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.2 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
       io.k8s.description="MariaDB is a multi-user, multi-threaded SQL database server" \
       io.k8s.display-name="MariaDB 10.2" \
       io.openshift.expose-services="3306:mysql" \
@@ -28,7 +34,8 @@ LABEL summary="MariaDB is a multi-user, multi-threaded SQL database server" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
-      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 $FGC/$NAME"
 
 EXPOSE 3306
 

--- a/10.2/Dockerfile.rhel7
+++ b/10.2/Dockerfile.rhel7
@@ -12,9 +12,8 @@ FROM rhscl/s2i-core-rhel7
 
 ENV MYSQL_VERSION=10.2 \
     APP_DATA=/opt/app-root/src \
-    HOME=/var/lib/mysql
-
-ENV SUMMARY="MariaDB 10.2 SQL database server" \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.2 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -28,7 +27,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102" \
       com.redhat.component="rh-mariadb102-docker" \
       name="rhscl/mariadb-102-rhel7" \
-      version="1"
+      version="1" \
+      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 registry.access.redhat.com/rhscl/mariadb-102-rhel7"
 
 EXPOSE 3306
 


### PR DESCRIPTION
https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md#other-labels

We're in a process of decommissioning our modular images: https://github.com/container-images/mariadb/pull/3. Since the modular variant is just about `dnf install -y $the_module` I don't think it makes sense to create a dedicated Dockerfile for such thing.