### PR TITLE
tests: replace removed s2i flag

### DIFF
--- a/test/run
+++ b/test/run
@@ -30,7 +30,7 @@ CIDFILE_DIR=$(mktemp --suffix=mysql_test_cidfiles -d)
 TESTSUITE_RESULT=1
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 
-s2i_args="--force-pull=false "
+s2i_args="--pull-policy=never "
 
 function cleanup() {
   local cidfile


### PR DESCRIPTION
Similarily to: sclorg/s2i-python-container#229