### PR TITLE
Various small documentation related changes

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb100-docker" \
       name="centos/mariadb-100-centos7" \
       version="10.0" \
-      release="1" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 centos/mariadb-100-centos7"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mariadb-100-centos7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.0/Dockerfile.rhel7
+++ b/10.0/Dockerfile.rhel7
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb100-docker" \
       name="rhscl/mariadb-100-rhel7" \
       version="10.0" \
-      release="13.3" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 registry.access.redhat.com/rhscl/mariadb-100-rhel7"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-100-rhel7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.0/root/usr/share/container-scripts/mysql/README.md
+++ b/10.0/root/usr/share/container-scripts/mysql/README.md
@@ -50,39 +50,75 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name       |    Description                            |
-| :--------------------- | ----------------------------------------- |
-|  `MYSQL_USER`          | User name for MySQL account to be created |
-|  `MYSQL_PASSWORD`      | Password for the user account             |
-|  `MYSQL_DATABASE`      | Database name                             |
-|  `MYSQL_ROOT_PASSWORD` | Password for the root user (optional)     |
+**`MYSQL_USER`**  
+       User name for MySQL account to be created
+
+**`MYSQL_PASSWORD`**  
+       Password for the user account
+
+**`MYSQL_DATABASE`**  
+       Database name
+
+**`MYSQL_ROOT_PASSWORD`**  
+       Password for the root user (optional)
+
 
 The following environment variables influence the MySQL configuration file. They are all optional.
 
-|    Variable name                |    Description                                                    |    Default
-| :------------------------------ | ----------------------------------------------------------------- | -------------------------------
-|  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
-|  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
-|  `MYSQL_MAX_ALLOWED_PACKET`     | The maximum size of one packet or any generated/intermediate string | 200M
-|  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
-|  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
-|  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
-|  `MYSQL_TABLE_OPEN_CACHE`       | The number of open tables for all threads                         |  400
-|  `MYSQL_KEY_BUFFER_SIZE`        | The size of the buffer used for index blocks                      |  32M (or 10% of available memory)
-|  `MYSQL_SORT_BUFFER_SIZE`       | The size of the buffer used for sorting                           |  256K
-|  `MYSQL_READ_BUFFER_SIZE`       | The size of the buffer used for a sequential scan                 |  8M (or 5% of available memory)
-|  `MYSQL_INNODB_BUFFER_POOL_SIZE`| The size of the buffer pool where InnoDB caches table and index data |  32M (or 50% of available memory)
-|  `MYSQL_INNODB_LOG_FILE_SIZE`   | The size of each log file in a log group                          |  8M (or 15% of available available)
-|  `MYSQL_INNODB_LOG_BUFFER_SIZE` | The size of the buffer that InnoDB uses to write to the log files on disk | 8M (or 15% of available memory)
-|  `MYSQL_DEFAULTS_FILE`          | Point to an alternative configuration file                        |  /etc/my.cnf
-|  `MYSQL_BINLOG_FORMAT`          | Set sets the binlog format, supported values are `row` and `statement` | statement
-|  `MYSQL_LOG_QUERIES_ENABLED`    | To enable query logging set this to `1`                           | 0
+**`MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)`**  
+       Sets how the table names are stored and compared
+
+**`MYSQL_MAX_CONNECTIONS (default: 151)`**  
+       The maximum permitted number of simultaneous client connections
+
+**`MYSQL_MAX_ALLOWED_PACKET (default: 200M)`**  
+       The maximum size of one packet or any generated/intermediate string
+
+**`MYSQL_FT_MIN_WORD_LEN (default: 4)`**  
+       The minimum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_FT_MAX_WORD_LEN (default: 20)`**  
+       The maximum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_AIO (default: 1)`**  
+       Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529
+
+**`MYSQL_TABLE_OPEN_CACHE (default: 400)`**  
+       The number of open tables for all threads
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 32M (or 10% of available memory))`**  
+       The size of the buffer used for index blocks
+
+**`MYSQL_SORT_BUFFER_SIZE (default: 256K)`**  
+       The size of the buffer used for sorting
+
+**`MYSQL_READ_BUFFER_SIZE (default: 8M (or 5% of available memory))`**  
+       The size of the buffer used for a sequential scan
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M (or 50% of available memory))`**  
+       The size of the buffer pool where InnoDB caches table and index data
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 8M (or 15% of available available))`**  
+       The size of each log file in a log group
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M (or 15% of available memory))`**  
+       The size of the buffer that InnoDB uses to write to the log files on disk
+
+**`MYSQL_DEFAULTS_FILE (default: /etc/my.cnf)`**  
+       Point to an alternative configuration file
+
+**`MYSQL_BINLOG_FORMAT (default: statement)`**  
+       Set sets the binlog format, supported values are `row` and `statement`
+
+**`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
+       To enable query logging set this to `1`
+
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
-|  Volume mount point      | Description          |
-| :----------------------- | -------------------- |
-|  `/var/lib/mysql/data`   | MySQL data directory |
+**`/var/lib/mysql/data`**  
+       MySQL data directory
+
 
 **Notice: When mouting a directory from the host into the container, ensure that the mounted
 directory has the appropriate permissions and that the owner and group of the directory
@@ -96,13 +132,21 @@ When the MySQL image is run with the `--memory` parameter set and you didn't
 specify value for some parameters, their values will be automatically
 calculated based on the available memory.
 
-| Variable name                   | Configuration parameter   | Relative value
-| :-------------------------------| ------------------------- | --------------
-| `MYSQL_KEY_BUFFER_SIZE`         | `key_buffer_size`         | 10%
-| `MYSQL_READ_BUFFER_SIZE`        | `read_buffer_size`        | 5%
-| `MYSQL_INNODB_BUFFER_POOL_SIZE` | `innodb_buffer_pool_size` | 50%
-| `MYSQL_INNODB_LOG_FILE_SIZE`    | `innodb_log_file_size`    | 15%
-| `MYSQL_INNODB_LOG_BUFFER_SIZE`  | `innodb_log_buffer_size`  | 15%
+**`MYSQL_KEY_BUFFER_SIZE (default: 10%)`**  
+       `key_buffer_size`
+
+**`MYSQL_READ_BUFFER_SIZE (default: 5%)`**  
+       `read_buffer_size`
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 50%)`**  
+       `innodb_buffer_pool_size`
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 15%)`**  
+       `innodb_log_file_size`
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 15%)`**  
+       `innodb_log_buffer_size`
+
 
 
 MySQL root user

--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb101-docker" \
       name="centos/mariadb-101-centos7" \
       version="10.1" \
-      release="1" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 centos/mariadb-101-centos7"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mariadb-101-centos7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -34,8 +34,8 @@ LABEL summary="$SUMMARY" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
-      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 $FGC/$NAME"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 $FGC/$NAME" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.1/Dockerfile.rhel7
+++ b/10.1/Dockerfile.rhel7
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-mariadb101-docker" \
       name="rhscl/mariadb-101-rhel7" \
       version="10.1" \
-      release="1" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 registry.access.redhat.com/rhscl/mariadb-101-rhel7"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-101-rhel7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.1/root/usr/share/container-scripts/mysql/README.md
+++ b/10.1/root/usr/share/container-scripts/mysql/README.md
@@ -50,39 +50,75 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name       |    Description                            |
-| :--------------------- | ----------------------------------------- |
-|  `MYSQL_USER`          | User name for MySQL account to be created |
-|  `MYSQL_PASSWORD`      | Password for the user account             |
-|  `MYSQL_DATABASE`      | Database name                             |
-|  `MYSQL_ROOT_PASSWORD` | Password for the root user (optional)     |
+**`MYSQL_USER`**  
+       User name for MySQL account to be created
+
+**`MYSQL_PASSWORD`**  
+       Password for the user account
+
+**`MYSQL_DATABASE`**  
+       Database name
+
+**`MYSQL_ROOT_PASSWORD`**  
+       Password for the root user (optional)
+
 
 The following environment variables influence the MySQL configuration file. They are all optional.
 
-|    Variable name                |    Description                                                    |    Default
-| :------------------------------ | ----------------------------------------------------------------- | -------------------------------
-|  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
-|  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
-|  `MYSQL_MAX_ALLOWED_PACKET`     | The maximum size of one packet or any generated/intermediate string | 200M
-|  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
-|  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
-|  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
-|  `MYSQL_TABLE_OPEN_CACHE`       | The number of open tables for all threads                         |  400
-|  `MYSQL_KEY_BUFFER_SIZE`        | The size of the buffer used for index blocks                      |  32M (or 10% of available memory)
-|  `MYSQL_SORT_BUFFER_SIZE`       | The size of the buffer used for sorting                           |  256K
-|  `MYSQL_READ_BUFFER_SIZE`       | The size of the buffer used for a sequential scan                 |  8M (or 5% of available memory)
-|  `MYSQL_INNODB_BUFFER_POOL_SIZE`| The size of the buffer pool where InnoDB caches table and index data |  32M (or 50% of available memory)
-|  `MYSQL_INNODB_LOG_FILE_SIZE`   | The size of each log file in a log group                          |  8M (or 15% of available available)
-|  `MYSQL_INNODB_LOG_BUFFER_SIZE` | The size of the buffer that InnoDB uses to write to the log files on disk | 8M (or 15% of available memory)
-|  `MYSQL_DEFAULTS_FILE`          | Point to an alternative configuration file                        |  /etc/my.cnf
-|  `MYSQL_BINLOG_FORMAT`          | Set sets the binlog format, supported values are `row` and `statement` | statement
-|  `MYSQL_LOG_QUERIES_ENABLED`    | To enable query logging set this to `1`                           | 0
+**`MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)`**  
+       Sets how the table names are stored and compared
+
+**`MYSQL_MAX_CONNECTIONS (default: 151)`**  
+       The maximum permitted number of simultaneous client connections
+
+**`MYSQL_MAX_ALLOWED_PACKET (default: 200M)`**  
+       The maximum size of one packet or any generated/intermediate string
+
+**`MYSQL_FT_MIN_WORD_LEN (default: 4)`**  
+       The minimum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_FT_MAX_WORD_LEN (default: 20)`**  
+       The maximum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_AIO (default: 1)`**  
+       Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529
+
+**`MYSQL_TABLE_OPEN_CACHE (default: 400)`**  
+       The number of open tables for all threads
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)`**  
+       The size of the buffer used for index blocks
+
+**`MYSQL_SORT_BUFFER_SIZE (default: 256K)`**  
+       The size of the buffer used for sorting
+
+**`MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)`**  
+       The size of the buffer used for a sequential scan
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)`**  
+       The size of the buffer pool where InnoDB caches table and index data
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available available)`**  
+       The size of each log file in a log group
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)`**  
+       The size of the buffer that InnoDB uses to write to the log files on disk
+
+**`MYSQL_DEFAULTS_FILE (default: /etc/my.cnf)`**  
+       Point to an alternative configuration file
+
+**`MYSQL_BINLOG_FORMAT (default: statement)`**  
+       Set sets the binlog format, supported values are `row` and `statement`
+
+**`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
+       To enable query logging set this to `1`
+
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
-|  Volume mount point      | Description          |
-| :----------------------- | -------------------- |
-|  `/var/lib/mysql/data`   | MySQL data directory |
+**`/var/lib/mysql/data`**  
+       MySQL data directory
+
 
 **Notice: When mouting a directory from the host into the container, ensure that the mounted
 directory has the appropriate permissions and that the owner and group of the directory
@@ -96,13 +132,21 @@ When the MySQL image is run with the `--memory` parameter set and you didn't
 specify value for some parameters, their values will be automatically
 calculated based on the available memory.
 
-| Variable name                   | Configuration parameter   | Relative value
-| :-------------------------------| ------------------------- | --------------
-| `MYSQL_KEY_BUFFER_SIZE`         | `key_buffer_size`         | 10%
-| `MYSQL_READ_BUFFER_SIZE`        | `read_buffer_size`        | 5%
-| `MYSQL_INNODB_BUFFER_POOL_SIZE` | `innodb_buffer_pool_size` | 50%
-| `MYSQL_INNODB_LOG_FILE_SIZE`    | `innodb_log_file_size`    | 15%
-| `MYSQL_INNODB_LOG_BUFFER_SIZE`  | `innodb_log_buffer_size`  | 15%
+**`MYSQL_KEY_BUFFER_SIZE (default: 10%)`**  
+       `key_buffer_size`
+
+**`MYSQL_READ_BUFFER_SIZE (default: 5%)`**  
+       `read_buffer_size`
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 50%)`**  
+       `innodb_buffer_pool_size`
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 15%)`**  
+       `innodb_log_file_size`
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 15%)`**  
+       `innodb_log_buffer_size`
+
 
 
 MySQL root user

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -27,8 +27,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102,galera" \
       com.redhat.component="rh-mariadb102-docker" \
       name="centos/mariadb-102-centos7" \
-      version="1" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 centos/mariadb-102-centos7"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mariadb-102-centos7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.2/Dockerfile.fedora
+++ b/10.2/Dockerfile.fedora
@@ -34,8 +34,8 @@ LABEL summary="$SUMMARY" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
-      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 $FGC/$NAME"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 $FGC/$NAME" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.2/Dockerfile.rhel7
+++ b/10.2/Dockerfile.rhel7
@@ -27,8 +27,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102" \
       com.redhat.component="rh-mariadb102-docker" \
       name="rhscl/mariadb-102-rhel7" \
-      version="1" \
-      usage="docker run -e MYSQL_USER=<user_name> -e MYSQL_PASSWORD=<password> -e MYSQL_DATABASE=<db_name> -e MYSQL_ROOT_PASSWORD=<root_password> -p 3306:3306 registry.access.redhat.com/rhscl/mariadb-102-rhel7"
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-102-rhel7" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
 

--- a/10.2/root/usr/share/container-scripts/mysql/README.md
+++ b/10.2/root/usr/share/container-scripts/mysql/README.md
@@ -50,39 +50,75 @@ Environment variables and volumes
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
-|    Variable name       |    Description                            |
-| :--------------------- | ----------------------------------------- |
-|  `MYSQL_USER`          | User name for MySQL account to be created |
-|  `MYSQL_PASSWORD`      | Password for the user account             |
-|  `MYSQL_DATABASE`      | Database name                             |
-|  `MYSQL_ROOT_PASSWORD` | Password for the root user (optional)     |
+**`MYSQL_USER`**  
+       User name for MySQL account to be created
+
+**`MYSQL_PASSWORD`**  
+       Password for the user account
+
+**`MYSQL_DATABASE`**  
+       Database name
+
+**`MYSQL_ROOT_PASSWORD`**  
+       Password for the root user (optional)
+
 
 The following environment variables influence the MySQL configuration file. They are all optional.
 
-|    Variable name                |    Description                                                    |    Default
-| :------------------------------ | ----------------------------------------------------------------- | -------------------------------
-|  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
-|  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
-|  `MYSQL_MAX_ALLOWED_PACKET`     | The maximum size of one packet or any generated/intermediate string | 200M
-|  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
-|  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
-|  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
-|  `MYSQL_TABLE_OPEN_CACHE`       | The number of open tables for all threads                         |  400
-|  `MYSQL_KEY_BUFFER_SIZE`        | The size of the buffer used for index blocks                      |  32M (or 10% of available memory)
-|  `MYSQL_SORT_BUFFER_SIZE`       | The size of the buffer used for sorting                           |  256K
-|  `MYSQL_READ_BUFFER_SIZE`       | The size of the buffer used for a sequential scan                 |  8M (or 5% of available memory)
-|  `MYSQL_INNODB_BUFFER_POOL_SIZE`| The size of the buffer pool where InnoDB caches table and index data |  32M (or 50% of available memory)
-|  `MYSQL_INNODB_LOG_FILE_SIZE`   | The size of each log file in a log group                          |  8M (or 15% of available available)
-|  `MYSQL_INNODB_LOG_BUFFER_SIZE` | The size of the buffer that InnoDB uses to write to the log files on disk | 8M (or 15% of available memory)
-|  `MYSQL_DEFAULTS_FILE`          | Point to an alternative configuration file                        |  /etc/my.cnf
-|  `MYSQL_BINLOG_FORMAT`          | Set sets the binlog format, supported values are `row` and `statement` | statement
-|  `MYSQL_LOG_QUERIES_ENABLED`    | To enable query logging set this to `1`                           | 0
+**`MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)`**  
+       Sets how the table names are stored and compared
+
+**`MYSQL_MAX_CONNECTIONS (default: 151)`**  
+       The maximum permitted number of simultaneous client connections
+
+**`MYSQL_MAX_ALLOWED_PACKET (default: 200M)`**  
+       The maximum size of one packet or any generated/intermediate string
+
+**`MYSQL_FT_MIN_WORD_LEN (default: 4)`**  
+       The minimum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_FT_MAX_WORD_LEN (default: 20)`**  
+       The maximum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_AIO (default: 1)`**  
+       Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529
+
+**`MYSQL_TABLE_OPEN_CACHE (default: 400)`**  
+       The number of open tables for all threads
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)`**  
+       The size of the buffer used for index blocks
+
+**`MYSQL_SORT_BUFFER_SIZE (default: 256K)`**  
+       The size of the buffer used for sorting
+
+**`MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)`**  
+       The size of the buffer used for a sequential scan
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)`**  
+       The size of the buffer pool where InnoDB caches table and index data
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available available)`**  
+       The size of each log file in a log group
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)`**  
+       The size of the buffer that InnoDB uses to write to the log files on disk
+
+**`MYSQL_DEFAULTS_FILE (default: /etc/my.cnf)`**  
+       Point to an alternative configuration file
+
+**`MYSQL_BINLOG_FORMAT (default: statement)`**  
+       Set sets the binlog format, supported values are `row` and `statement`
+
+**`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
+       To enable query logging set this to `1`
+
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
-|  Volume mount point      | Description          |
-| :----------------------- | -------------------- |
-|  `/var/lib/mysql/data`   | MySQL data directory |
+**`/var/lib/mysql/data`**  
+       MySQL data directory
+
 
 **Notice: When mouting a directory from the host into the container, ensure that the mounted
 directory has the appropriate permissions and that the owner and group of the directory
@@ -96,13 +132,21 @@ When the MySQL image is run with the `--memory` parameter set and you didn't
 specify value for some parameters, their values will be automatically
 calculated based on the available memory.
 
-| Variable name                   | Configuration parameter   | Relative value
-| :-------------------------------| ------------------------- | --------------
-| `MYSQL_KEY_BUFFER_SIZE`         | `key_buffer_size`         | 10%
-| `MYSQL_READ_BUFFER_SIZE`        | `read_buffer_size`        | 5%
-| `MYSQL_INNODB_BUFFER_POOL_SIZE` | `innodb_buffer_pool_size` | 50%
-| `MYSQL_INNODB_LOG_FILE_SIZE`    | `innodb_log_file_size`    | 15%
-| `MYSQL_INNODB_LOG_BUFFER_SIZE`  | `innodb_log_buffer_size`  | 15%
+**`MYSQL_KEY_BUFFER_SIZE (default: 10%)`**  
+       `key_buffer_size`
+
+**`MYSQL_READ_BUFFER_SIZE (default: 5%)`**  
+       `read_buffer_size`
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 50%)`**  
+       `innodb_buffer_pool_size`
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 15%)`**  
+       `innodb_log_file_size`
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 15%)`**  
+       `innodb_log_buffer_size`
+
 
 
 MySQL root user

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ MariaDB SQL Database Server Docker Image
 ========================================
 
 This repository contains Dockerfiles for MariaDB images for OpenShift and general usage.
-Users can choose between RHEL and CentOS based images.
+Users can choose between RHEL, Fedora and CentOS based images.
 
 MariaDB container is very similar to the MySQL container available at
 [https://github.com/sclorg/mysql-container](https://github.com/sclorg/mysql-container).
@@ -21,6 +21,7 @@ Versions
 MariaDB versions currently provided are:
 * [MariaDB 10.0](10.0)
 * [MariaDB 10.1](10.1)
+* [MariaDB 10.1](10.1)
 
 RHEL versions currently supported are:
 * RHEL7
@@ -35,10 +36,11 @@ Choose either the CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
 
-    This image is available in Red Hat Container Registry. To download it run:
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/mariadb-102-rhel7).
+    To download it run:
 
     ```
-    $ docker pull registry.access.redhat.com/rhscl/mariadb-101-rhel7
+    $ docker pull registry.access.redhat.com/rhscl/mariadb-102-rhel7
     ```
 
     To build a RHEL7 based MariaDB image, you need to run Docker build on a properly
@@ -48,7 +50,7 @@ Choose either the CentOS7 or RHEL7 based image:
     $ git clone --recursive https://github.com/sclorg/mariadb-container.git
     $ cd mariadb-container
     $ git submodule update --init
-    $ make build TARGET=rhel7 VERSIONS=10.1
+    $ make build TARGET=rhel7 VERSIONS=10.2
     ```
 
 *  **CentOS7 based image**
@@ -56,7 +58,7 @@ Choose either the CentOS7 or RHEL7 based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ docker pull centos/mariadb-101-centos7
+    $ docker pull centos/mariadb-102-centos7
     ```
 
     To build a CentOS based MariaDB image from scratch, run:
@@ -65,10 +67,10 @@ Choose either the CentOS7 or RHEL7 based image:
     $ git clone --recursive https://github.com/sclorg/mariadb-container.git
     $ cd mariadb-container
     $ git submodule update --init
-    $ make build TARGET=centos7 VERSIONS=10.1
+    $ make build TARGET=centos7 VERSIONS=10.2
     ```
 
-For using other versions of MariaDB, just replace the `10.1` value by particular version
+For using other versions of MariaDB, just replace the `10.2` value by particular version
 in the commands above.
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
@@ -84,6 +86,9 @@ see [usage documentation](10.0).
 
 For information about usage of Dockerfile for MariaDB 10.1,
 see [usage documentation](10.1).
+
+For information about usage of Dockerfile for MariaDB 10.2,
+see [usage documentation](10.2).
 
 
 Test
@@ -102,7 +107,7 @@ Users can choose between testing MariaDB based on a RHEL or CentOS image.
     ```
     $ cd mariadb-container
     $ git submodule update --init
-    $ make test TARGET=rhel7 VERSIONS=10.1
+    $ make test TARGET=rhel7 VERSIONS=10.2
     ```
 
 *  **CentOS based image**
@@ -110,10 +115,10 @@ Users can choose between testing MariaDB based on a RHEL or CentOS image.
     ```
     $ cd mariadb-container
     $ git submodule update --init
-    $ make test TARGET=centos7 VERSIONS=10.1
+    $ make test TARGET=centos7 VERSIONS=10.2
     ```
 
-For using other versions of MariaDB, just replace the `10.1` value by particular version
+For using other versions of MariaDB, just replace the `10.2` value by particular version
 in the commands above.
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed

--- a/root-common/usr/bin/usage
+++ b/root-common/usr/bin/usage
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cat /usr/share/container-scripts/mysql/README.md
+


### PR DESCRIPTION
Use maintainer label consistently
Few edits in top-level README
Using usage label and command
Remove tables in README, because go-md2man cannot convert them properly