### PR TITLE
Add removed version label back to 10.2 Dockerfiles

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -27,6 +27,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102,galera" \
       com.redhat.component="rh-mariadb102-docker" \
       name="centos/mariadb-102-centos7" \
+      version="1" \
       usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mariadb-102-centos7" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/10.2/Dockerfile.rhel7
+++ b/10.2/Dockerfile.rhel7
@@ -27,6 +27,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="database,mysql,mariadb,mariadb102,rh-mariadb102" \
       com.redhat.component="rh-mariadb102-docker" \
       name="rhscl/mariadb-102-rhel7" \
+      version="1" \
       usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhscl/mariadb-102-rhel7" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 


### PR DESCRIPTION
Removed via https://github.com/sclorg/mariadb-container/commit/00be2e121d91c559ba5274335c9b7220a47422a0