### PR TITLE
Use released repos only

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -36,7 +36,6 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum install -y centos-release-scl-rh && \
-    yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils rh-mariadb102" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
It is not necessary to use testing repo now anymore, all packages are in released repo already.