### PR TITLE
Fix for datadir on GlusterFS.

### DIFF
--- a/root-common/etc/my.cnf
+++ b/root-common/etc/my.cnf
@@ -9,4 +9,7 @@ skip_name_resolve
 # http://www.chriscalender.com/ignoring-the-lostfound-directory-in-your-datadir/
 ignore-db-dir=lost+found
 
+# GlusterFS equivalent of 'lost+found'
+ignore-db-dir=.trashcan
+
 !includedir /etc/my.cnf.d


### PR DESCRIPTION
This will fix crashing of the MariaDB image in the OpenShift catalog on init when using GlusterFS as storage backend. 

GlusterFS will mount the volume directly on /var/lib/mysql/data and by default a new volume will have a .trashcan dir. The init scripts of MariaDB will fall over this empty dir with the error : 
`[ERROR] Invalid (old?) table or database name '.trashcan'
mysqlcheck: Got error: 1102: Incorrect database name '#mysql50#.trashcan' when selecting the database
FATAL ERROR: Upgrade failed
`

The ignore-db-dir option can be added multiple times to add on each other. 