### PR TITLE
Remove release label

### DIFF
--- a/10.1/Dockerfile.fedora
+++ b/10.1/Dockerfile.fedora
@@ -15,7 +15,6 @@ ENV MYSQL_VERSION=10.1 \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     VERSION=10.1 \
-    RELEASE=1 \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.1 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
@@ -32,8 +31,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
       usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 $FGC/$NAME" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -64,8 +61,10 @@ COPY 10.1/root /
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
+# Also reset permissions of filesystem to default values
 RUN rm -rf /etc/my.cnf.d/* && \
-    /usr/libexec/container-setup
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
 
 VOLUME ["/var/lib/mysql/data"]
 

--- a/10.2/Dockerfile.fedora
+++ b/10.2/Dockerfile.fedora
@@ -46,10 +46,6 @@ RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base shadow-utils 
     mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
-# On Fedora, we fake missing python binary. In case user installs the python2
-# in the container, this hack will be removed by installing /usr/bin/python from RPM.
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.2/Dockerfile.fedora
+++ b/10.2/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f27/s2i-core:latest
+FROM registry.fedoraproject.org/f28/s2i-core:latest
 
 # MariaDB image for OpenShift.
 #
@@ -15,7 +15,6 @@ ENV MYSQL_VERSION=10.2 \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     VERSION=10.2 \
-    RELEASE=1 \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.2 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
@@ -32,8 +31,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
       usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 $FGC/$NAME" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -64,8 +61,10 @@ COPY 10.2/root /
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
+# Also reset permissions of filesystem to default values
 RUN rm -rf /etc/my.cnf.d/* && \
-    /usr/libexec/container-setup
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
 
 VOLUME ["/var/lib/mysql/data"]
 


### PR DESCRIPTION
Remove release label - in Fedora it's updated automatically by build system.

Remove arch label - 'Optional: if omitted, it will be built for
all supported Fedora Architectures'

+ make fedora Dockerfile more similar to other OSes

@pkubatrh Please take a look and merge.