### PR TITLE
Removing Version Typo from Image Stream Descriptions

### DIFF
--- a/imagestreams/mariadb-centos7.json
+++ b/imagestreams/mariadb-centos7.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "MariaDB (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major versions updates.",
+          "description": "Provides a MariaDB database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb"
         },

--- a/imagestreams/mariadb-rhel7-ppc64le.json
+++ b/imagestreams/mariadb-rhel7-ppc64le.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "MariaDB (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major versions updates.",
+          "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb,ppc64le"
         },

--- a/imagestreams/mariadb-rhel7.json
+++ b/imagestreams/mariadb-rhel7.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "MariaDB (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major versions updates.",
+          "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb"
         },


### PR DESCRIPTION
This pull request removes a minor typo for all the image stream descriptions.