### PR TITLE
Add s390x image stream and add 10.3 version

### DIFF
--- a/imagestreams/mariadb-centos7.json
+++ b/imagestreams/mariadb-centos7.json
@@ -14,13 +14,13 @@
         "annotations": {
           "openshift.io/display-name": "MariaDB (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
+          "description": "Provides a MariaDB database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb"
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10.2"
+          "name": "10.3"
         },
         "referencePolicy": {
           "type": "Local"
@@ -39,6 +39,24 @@
         "from": {
           "kind": "DockerImage",
           "name": "docker.io/centos/mariadb-102-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+       },
+       {
+        "name": "10.3",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.3",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.3 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.3"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/centos/mariadb-103-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/mariadb-rhel7-ppc64le.json
+++ b/imagestreams/mariadb-rhel7-ppc64le.json
@@ -14,13 +14,13 @@
         "annotations": {
           "openshift.io/display-name": "MariaDB (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
+          "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb,ppc64le"
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10.2"
+          "name": "10.3"
         },
         "referencePolicy": {
           "type": "Local"
@@ -39,6 +39,24 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.3",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.3",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.3 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb,ppc64le",
+          "version": "10.3"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/mariadb-103-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/mariadb-rhel7-s390x.json
+++ b/imagestreams/mariadb-rhel7-s390x.json
@@ -16,7 +16,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Provides a MariaDB database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of MariaDB available on OpenShift, including major version updates.",
           "iconClass": "icon-mariadb",
-          "tags": "database,mariadb"
+          "tags": "database,mariadb,s390x"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -33,7 +33,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
           "iconClass": "icon-mariadb",
-          "tags": "database,mariadb",
+          "tags": "database,mariadb,s390x",
           "version": "10.2"
         },
         "from": {
@@ -51,7 +51,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Provides a MariaDB 10.3 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
           "iconClass": "icon-mariadb",
-          "tags": "database,mariadb",
+          "tags": "database,mariadb,s390x",
           "version": "10.3"
         },
         "from": {


### PR DESCRIPTION
This was asked by @siamaksade and @gabemontero and consulted more that we should be ok with just one imagestream file and more tags for alternate architectures. Once merged, we'll submit a PR for https://github.com/openshift/library/blob/master/official.yaml and add `arch_ppc64le` and `arch_s390x` tags there.

@siamaksade or @gabemontero, can you take a look and verify we understood each other well and we can continue with other images this way?