### PR TITLE
Update the image version on which this container should be built

### DIFF
--- a/10.3/Dockerfile.fedora
+++ b/10.3/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/s2i-core:latest
+FROM registry.fedoraproject.org/f30/s2i-core:latest
 
 # MariaDB image for OpenShift.
 #


### PR DESCRIPTION
F29 is currently dead. F30 is currently the oldest supported Fedora version.