### PR TITLE
Fixes BZ#1653215 Operation ALTER USER failed

### DIFF
--- a/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
+++ b/root-common/usr/share/container-scripts/mysql/init/50-passwd-change.sh
@@ -4,9 +4,14 @@ password_change() {
   # Set the password for MySQL user and root everytime this container is started.
   # This allows to change the password by editing the deployment configuration.
   if [[ -v MYSQL_USER && -v MYSQL_PASSWORD ]]; then
+    local user_maches=$(echo "SELECT COUNT(*) AS found FROM mysql.user WHERE user='${MYSQL_USER}' AND Host='%' \G" | mysql $mysql_flags)
+    if ! echo "${user_maches}" | grep -q 'found: 1' ; then
+      log_info "WARNING: User ${MYSQL_USER} does not exist in database. Password not changed."
+    else
 mysql $mysql_flags <<EOSQL
-      SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
+      ALTER USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
 EOSQL
+    fi
   fi
 
   # The MYSQL_ROOT_PASSWORD is optional, therefore we need to either enable remote

--- a/test/run
+++ b/test/run
@@ -154,7 +154,7 @@ function run_change_password_new_user_test() {
   test_connection testpassnewuser2 user foo
 
   # See whether there is an error message in the log
-  if ! docker logs $(ct_get_cid testpassnewuser2) | grep 'User .*user2.* does not exist in database' ; then
+  if ! docker logs $(ct_get_cid testpassnewuser2) | grep 'User user2 does not exist in database' ; then
     echo "ERROR: Container did not end with expected error message: 'User user2 does not exist in database'."
     return 1
   fi

--- a/test/run
+++ b/test/run
@@ -18,6 +18,7 @@ run_container_creation_tests
 run_configuration_tests
 run_general_tests
 run_change_password_test
+run_change_password_new_user_test
 run_replication_test
 run_doc_test
 run_s2i_test
@@ -133,6 +134,34 @@ function run_change_password_test() {
 
   # The old password should not work anymore
   if mysql_cmd "$(ct_get_cip testpass2)" user foo -e 'SELECT 1;'; then
+    return 1
+  fi
+}
+
+function run_change_password_new_user_test() {
+  local tmpdir=$(mktemp -d)
+  chmod -R a+rwx "${tmpdir}"
+
+  # Create MySQL container with persistent volume and set the initial password
+  create_container "testpassnewuser1" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${tmpdir}:/var/lib/mysql/data:Z
+  test_connection testpassnewuser1 user foo
+  docker stop $(ct_get_cid testpassnewuser1) >/dev/null
+
+  # Create second container with changed password
+  create_container "testpassnewuser2" -e MYSQL_USER=user2 -e MYSQL_PASSWORD=bar \
+    -e MYSQL_DATABASE=db -v ${tmpdir}:/var/lib/mysql/data:Z
+  test_connection testpassnewuser2 user foo
+
+  # See whether there is an error message in the log
+  if ! docker logs $(ct_get_cid testpassnewuser2) | grep 'User .*user2.* does not exist in database' ; then
+    echo "ERROR: Container did not end with expected error message: 'User user2 does not exist in database'."
+    return 1
+  fi
+
+  # The new password should not work
+  if mysql_cmd "$(ct_get_cip testpassnewuser2)" user bar -e 'SELECT 1;'; then
+    echo "ERROR: The new password should not work, but it does."
     return 1
   fi
 }


### PR DESCRIPTION
When changing password for a different user, this user is not found in the database, so the container fails with:
```
ERROR 1396 (HY000) at line 1: Operation ALTER USER failed for 'newuser'@'%'
```
or
```
ERROR 1133 (28000) at line 1: Can't find any matching row in the user table
```

The change adds a specific check that the user exists, and the behaviour change is that in case the user does not exist, the container does not fail, only a warning is printed.

This is a same PR as https://github.com/sclorg/mysql-container/pull/269 and should also close #78.