### PR TITLE
Use mysqladmin for the liveness probe

### DIFF
--- a/examples/mariadb-ephemeral-template.json
+++ b/examples/mariadb-ephemeral-template.json
@@ -116,14 +116,15 @@
                   "initialDelaySeconds": 5,
                   "exec": {
                     "command": [ "/bin/sh", "-i", "-c",
-                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"]
                   }
                 },
                 "livenessProbe": {
                   "timeoutSeconds": 1,
                   "initialDelaySeconds": 30,
-                  "tcpSocket": {
-                    "port": 3306
+                  "exec": {
+                    "command": [ "/bin/sh", "-i", "-c",
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"]
                   }
                 },
                 "env": [

--- a/examples/mariadb-persistent-template.json
+++ b/examples/mariadb-persistent-template.json
@@ -133,14 +133,15 @@
                   "initialDelaySeconds": 5,
                   "exec": {
                     "command": [ "/bin/sh", "-i", "-c",
-                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'"]
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"]
                   }
                 },
                 "livenessProbe": {
                   "timeoutSeconds": 1,
                   "initialDelaySeconds": 30,
-                  "tcpSocket": {
-                    "port": 3306
+                  "exec": {
+                    "command": [ "/bin/sh", "-i", "-c",
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysqladmin -u $MYSQL_USER ping"]
                   }
                 },
                 "env": [


### PR DESCRIPTION
When using just TCP ping for the port, mysqld daemon expects some data that do not come. With "set global log_error_verbosity=3;", a warning is printed to the errlog, like this:
Got an error reading communication packets
(every 10s, depending on the liveness probe delay)

This makes issues when tools analyze the errlog, because those innoncent connection errors cannot be distinguised from real connection issues.

With using mysqladmin, similar to the readiness probe, the warning should not be printed any more.

Related: rhbz#1767393
Upstream issue: https://github.com/sclorg/mysql-container/issues/274
Upstream fix: https://github.com/sclorg/mysql-container/pull/285