### PR TITLE
Reorder imagestreams.

### DIFF
--- a/imagestreams/mariadb-centos7.json
+++ b/imagestreams/mariadb-centos7.json
@@ -27,24 +27,6 @@
         }
       },
       {
-        "name": "10.2",
-        "annotations": {
-          "openshift.io/display-name": "MariaDB 10.2",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB 10.2 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
-          "iconClass": "icon-mariadb",
-          "tags": "database,mariadb",
-          "version": "10.2"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "docker.io/centos/mariadb-102-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-       },
-       {
         "name": "10.3",
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.3",
@@ -61,7 +43,25 @@
         "referencePolicy": {
           "type": "Local"
         }
-      }
+      },
+      {
+        "name": "10.2",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.2",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.2 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.2"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/centos/mariadb-102-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+       }
     ]
   }
 }

--- a/imagestreams/mariadb-rhel7-ppc64le.json
+++ b/imagestreams/mariadb-rhel7-ppc64le.json
@@ -27,24 +27,6 @@
         }
       },
       {
-        "name": "10.2",
-        "annotations": {
-          "openshift.io/display-name": "MariaDB 10.2",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
-          "iconClass": "icon-mariadb",
-          "tags": "database,mariadb,ppc64le",
-          "version": "10.2"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "10.3",
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.3",
@@ -57,6 +39,24 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/rhscl/mariadb-103-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.2",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.2",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb,ppc64le",
+          "version": "10.2"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/mariadb-rhel7-s390x.json
+++ b/imagestreams/mariadb-rhel7-s390x.json
@@ -27,24 +27,6 @@
         }
       },
       {
-        "name": "10.2",
-        "annotations": {
-          "openshift.io/display-name": "MariaDB 10.2",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
-          "iconClass": "icon-mariadb",
-          "tags": "database,mariadb,s390x",
-          "version": "10.2"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "10.3",
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.3",
@@ -57,6 +39,24 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/rhscl/mariadb-103-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.2",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.2",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb,s390x",
+          "version": "10.2"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/mariadb-rhel7.json
+++ b/imagestreams/mariadb-rhel7.json
@@ -27,24 +27,6 @@
         }
       },
       {
-        "name": "10.2",
-        "annotations": {
-          "openshift.io/display-name": "MariaDB 10.2",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
-          "iconClass": "icon-mariadb",
-          "tags": "database,mariadb",
-          "version": "10.2"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "10.3",
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.3",
@@ -57,6 +39,24 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/rhscl/mariadb-103-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.2",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.2",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.2 database on RHEL 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.2/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.2"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Order is now: latest, 10.3 and 10.2.

We would like to test if the latest version is present in the imagestreams.
It is done by ansible-script (https://github.com/sclorg/ansible-tests/pull/4)

The second tag is going to be used for test if version is the latest.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>
