### PR TITLE
Support MYSQL_CHARSET and MYSQL_COLLATION variables

### DIFF
--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -9,6 +9,8 @@ FROM centos/s2i-core-centos7
 #  * $MYSQL_PASSWORD - User's password
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+#  * $MYSQL_CHARSET (Optional) - Default character set
+#  * $MYSQL_COLLATION (Optional) - Default collation
 
 ENV MYSQL_VERSION=10.3 \
     APP_DATA=/opt/app-root/src \

--- a/10.3/root/usr/share/container-scripts/mysql/README.md
+++ b/10.3/root/usr/share/container-scripts/mysql/README.md
@@ -63,6 +63,12 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 **`MYSQL_ROOT_PASSWORD`**  
        Password for the root user (optional)
 
+**`MYSQL_CHARSET`**  
+       Default character set (optional)
+
+**`MYSQL_COLLATION`**  
+       Default collation (optional)
+
 
 The following environment variables influence the MySQL configuration file. They are all optional.
 

--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -136,6 +136,19 @@ EOSQL
   if [ -v MYSQL_DATABASE ]; then
     log_info "Creating database ${MYSQL_DATABASE} ..."
     mysqladmin $admin_flags create "${MYSQL_DATABASE}"
+    if [ -v MYSQL_CHARSET ]; then
+        log_info "Changing character set to ${MYSQL_CHARSET} ..."
+mysql $mysql_flags <<EOSQL
+      ALTER DATABASE \`${MYSQL_DATABASE}\` CHARACTER SET \`${MYSQL_CHARSET}\` ;
+EOSQL
+    fi
+    if [ -v MYSQL_COLLATION ]; then
+        log_info "Changing collation to ${MYSQL_COLLATION} ..."
+mysql $mysql_flags <<EOSQL
+      ALTER DATABASE \`${MYSQL_DATABASE}\` COLLATE \`${MYSQL_COLLATION}\` ;
+EOSQL
+    fi
+
     if [ -v MYSQL_USER ]; then
       log_info "Granting privileges to user ${MYSQL_USER} for ${MYSQL_DATABASE} ..."
 mysql $mysql_flags <<EOSQL

--- a/test/run
+++ b/test/run
@@ -370,6 +370,8 @@ function run_configuration_tests() {
 
   DOCKER_ARGS='--memory=256m' create_container \
     "$container_name" \
+    --env MYSQL_COLLATION=latin2_czech_cs \
+    --env MYSQL_CHARSET=latin2 \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db
@@ -383,6 +385,13 @@ function run_configuration_tests() {
   test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 128M
   test_config_option "$container_name" "$configuration" innodb_log_file_size 38M
   test_config_option "$container_name" "$configuration" innodb_log_buffer_size 38M
+
+  # check character set and collation
+  container_ip=$(ct_get_cip $container_name)
+  mysql_cmd "$container_ip" config_test_user config_test -e 'CREATE TABLE tbl (col1 VARCHAR(20));'
+  tbl_def=$(mysql_cmd "$container_ip" config_test_user config_test -e 'SHOW CREATE TABLE tbl;')
+  echo "$tbl_def" | grep -e 'CHARSET=latin2'
+  echo "$tbl_def" | grep -e 'COLLATE=latin2_czech_cs'
 
   docker stop "$(ct_get_cid $container_name)" >/dev/null
 


### PR DESCRIPTION
like the centos/mariadb (5.5) container does

Question: I see these variables listed in multiple Dockerfile files. Should all of them be updated ?

Any ETA when this could make it into Docker Hub or a reasonable workaround ?