### PR TITLE
[WIP] Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -18,6 +18,8 @@ trap ct_os_cleanup EXIT SIGINT
 
 ct_os_check_compulsory_vars
 
+ct_os_enable_print_logs
+
 ct_os_cluster_up
 
 test_mysql_pure_image "${IMAGE_NAME}"
@@ -27,6 +29,8 @@ test_mysql_template "${IMAGE_NAME}"
 # TODO: Can we make the build against examples inside the same PR?
 test_mysql_s2i "${IMAGE_NAME}" "https://github.com/sclorg/mariadb-container.git" test/test-app
 
+# test with the just built image and an integrated template
+echo "Running test_mariadb_integration with ${IMAGE_NAME}"
 test_mariadb_integration "${IMAGE_NAME}" "${VERSION}" mariadb
 
 # test with a released image and an integrated template
@@ -39,16 +43,22 @@ else
   fail_not_released=false
 fi
 
-export CT_SKIP_UPLOAD_IMAGE=true
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
-  test_mariadb_integration mariadb "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+  echo "Running test_mariadb_integration with ${PUBLIC_IMAGE_NAME}"
+  test_mariadb_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" mariadb
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
   ! $fail_not_released || false "ERROR: Failed to pull image"
 fi
 
+# Check the imagestream
+echo "Running test_mariadb_imagestream"
+test_mariadb_imagestream
+
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -58,7 +58,10 @@ test_mariadb_imagestream
 
 OS_TESTSUITE_RESULT=0
 
-ct_os_cluster_down
+# Work-around: trying to disable cluster disposal to avoid errors like:
+# https://gist.github.com/rhscl-bot/c0e70f2cd3e44318db807e66895e0226
+# Error response from daemon: Get http://172.30.1.1:5000/v1/users/: dial tcp 172.30.1.1:5000: connect: connection refused
+# ct_os_cluster_down
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -31,25 +31,19 @@ test_mysql_s2i "${IMAGE_NAME}" "https://github.com/sclorg/mariadb-container.git"
 
 # test with the just built image and an integrated template
 echo "Running test_mariadb_integration with ${IMAGE_NAME}"
-test_mariadb_integration "${IMAGE_NAME}" "${VERSION}" mariadb
+test_mariadb_integration "${IMAGE_NAME}"
 
 # test with a released image and an integrated template
-# ignore possible failure of this test for centos images
-fail_not_released=true
-if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
-else
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
-  fail_not_released=false
-fi
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
 
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
   echo "Running test_mariadb_integration with ${PUBLIC_IMAGE_NAME}"
-  test_mariadb_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" mariadb
+  test_mariadb_integration "${PUBLIC_IMAGE_NAME}"
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
-  ! $fail_not_released || false "ERROR: Failed to pull image"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
 fi
 
 # Check the imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -25,7 +25,7 @@ export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
 # Check the template
-test_mariadb_integration "${IMAGE_NAME}" ${VERSION} mariadb
+test_mariadb_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_mariadb_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,13 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_mariadb_integration mariadb ${VERSION} "${IMAGE_NAME}"
+# Check the template
+test_mariadb_integration "${IMAGE_NAME}" ${VERSION} mariadb
+
+# Check the imagestream
+test_mariadb_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -114,18 +114,29 @@ function test_mysql_s2i() {
 function test_mariadb_integration() {
   local image_name=$1
   local VERSION=$2
-  local import_image=$3
-  local service_name=${import_image##*/}
+  local service_name=$3
+  local image_tagged="${service_name}:${VERSION}"
   ct_os_template_exists mariadb-ephemeral && t=mariadb-ephemeral || t=mariadb-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \
                                "${service_name}" \
-                               "ct_os_check_cmd_internal '${import_image}' '${service_name}' \"echo 'SELECT 42 as testval\g' | mysql --connect-timeout=15 -h <IP> testdb -utestu -ptestp\" '^42' 120" \
+                               "ct_os_check_cmd_internal '<SAME_IMAGE>' '${service_name}-testing' \"echo 'SELECT 42 as testval\g' | mysql --connect-timeout=15 -h <IP> testdb -utestu -ptestp\" '^42' 120" \
                                "-p MARIADB_VERSION=${VERSION} \
                                 -p DATABASE_SERVICE_NAME="${service_name}-testing" \
                                 -p MYSQL_USER=testu \
                                 -p MYSQL_PASSWORD=testp \
-                                -p MYSQL_DATABASE=testdb" "" "${import_image}"
+                                -p MYSQL_DATABASE=testdb"
+}
+
+
+# Check the imagestream
+function test_mariadb_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -113,9 +113,7 @@ function test_mysql_s2i() {
 
 function test_mariadb_integration() {
   local image_name=$1
-  local VERSION=$2
-  local service_name=$3
-  local image_tagged="${service_name}:${VERSION}"
+  local service_name=mariadb
   ct_os_template_exists mariadb-ephemeral && t=mariadb-ephemeral || t=mariadb-persistent
   ct_os_test_template_app_func "${image_name}" \
                                "${t}" \


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster