### PR TITLE
Update fedora version

### DIFF
--- a/10.3/Dockerfile.fedora
+++ b/10.3/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/s2i-core:latest
+FROM registry.fedoraproject.org/f31/s2i-core:latest
 
 # MariaDB image for OpenShift.
 #


### PR DESCRIPTION
Removed .exclude-fedora to enabled Fedora build. Updated Fedora version from 29 to 31 (still using MariaDB 10.3) and tested using "make test" and real-live deployment on OKD.