### PR TITLE
Move testing imagestream into openshift tests

### DIFF
--- a/test/run
+++ b/test/run
@@ -24,7 +24,6 @@ run_doc_test
 run_s2i_test
 run_ssl_test
 run_upgrade_test
-run_latest_imagestreams
 "
 
 if [ -e "${IMAGE_NAME:-}" ] ; then
@@ -654,17 +653,6 @@ function run_upgrade_test() {
 
   echo "  Upgrade tests succeeded!"
   echo
-}
-
-function run_latest_imagestreams() {
-  local result=1
-  # Switch to root directory of a container
-  echo "Testing the latest version in imagestreams"
-  pushd "${test_dir}/.." >/dev/null || return 1
-  ct_check_latest_imagestreams
-  result=$?
-  popd >/dev/null || return 1
-  return $result
 }
 
 function run_all_tests() {

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -42,7 +42,7 @@ if docker pull "${PUBLIC_IMAGE_NAME}"; then
   test_mariadb_integration "${PUBLIC_IMAGE_NAME}"
 
   if [[ "${OS}" =~ rhel7 ]] || [[ "${OS}" =~ centos7 ]] ; then
-    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS}.json" "${THISDIR}/mariadb-ephemeral-template.json" mariadb
+    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%%[0-9]*}.json" "${THISDIR}/mariadb-ephemeral-template.json" mariadb
   fi
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
@@ -53,6 +53,19 @@ fi
 # Check the imagestream
 echo "Running test_mariadb_imagestream"
 test_mariadb_imagestream
+
+function run_latest_imagestreams() {
+  local result=1
+  # Switch to root directory of a container
+  echo "Testing the latest version in imagestreams"
+  pushd "${THISDIR}/.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  return $result
+}
+
+run_latest_imagestreams
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -54,17 +54,7 @@ fi
 echo "Running test_mariadb_imagestream"
 test_mariadb_imagestream
 
-function run_latest_imagestreams() {
-  local result=1
-  # Switch to root directory of a container
-  echo "Testing the latest version in imagestreams"
-  pushd "${THISDIR}/.." >/dev/null || return 1
-  ct_check_latest_imagestreams
-  result=$?
-  popd >/dev/null || return 1
-  return $result
-}
-
+echo "Check the latest imagestreams"
 run_latest_imagestreams
 
 OS_TESTSUITE_RESULT=0

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -137,4 +137,15 @@ function test_mariadb_imagestream() {
   ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS%%[0-9]*}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}"
 }
 
+# Check the latest imagestreams
+function run_latest_imagestreams() {
+  local result=1
+  # Switch to root directory of a container
+  echo "Testing the latest version in imagestreams"
+  pushd "${THISDIR}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  return $result
+}
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -46,13 +46,13 @@ function check_mysql_os_service_connection() {
 function test_mysql_pure_image() {
   local image_name=${1:-centos/mariadb-101-centos7}
   local image_name_no_namespace=${image_name##*/}
-  local service_name=${image_name_no_namespace}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
   # Create a specific imagestream tag for the image so that oc cannot use anything else
-  ct_os_upload_image "${image_name}" "$image_name_no_namespace:testing"
+  ct_os_upload_image "${image_name}" "$image_name_no_namespace"
 
-  ct_os_deploy_pure_image "$image_name_no_namespace:testing" \
+  ct_os_deploy_pure_image "$image_name_no_namespace" \
                           --name "${service_name}" \
                           --env MYSQL_ROOT_PASSWORD=test
 
@@ -65,7 +65,7 @@ function test_mysql_pure_image() {
 function test_mysql_template() {
   local image_name=${1:-centos/mariadb-101-centos7}
   local image_name_no_namespace=${image_name##*/}
-  local service_name=${image_name_no_namespace}
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
   ct_os_upload_image "${image_name}" "mariadb:$VERSION"
@@ -89,13 +89,13 @@ function test_mysql_s2i() {
   local app=${2:-https://github.com/sclorg/mariadb-container.git}
   local context_dir=${3:-test/test-app}
   local image_name_no_namespace=${image_name##*/}
-  local service_name="${image_name_no_namespace}-testing"
+  local service_name="${image_name_no_namespace%%:*}-testing"
 
   ct_os_new_project
   # Create a specific imagestream tag for the image so that oc cannot use anything else
-  ct_os_upload_image "${image_name}" "$image_name_no_namespace:testing"
+  ct_os_upload_image "${image_name}" "$image_name_no_namespace"
 
-  ct_os_deploy_s2i_image "$image_name_no_namespace:testing" "${app}" \
+  ct_os_deploy_s2i_image "$image_name_no_namespace" "${app}" \
                           --context-dir="${context_dir}" \
                           --name "${service_name}" \
                           --env MYSQL_ROOT_PASSWORD=test \
@@ -134,7 +134,7 @@ function test_mariadb_imagestream() {
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 
-  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}"
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS%%[0-9]*}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
Move testing imagestream into openshift tests.

Container-common-scripts are updated into the latest.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>