### PR TITLE
Update README.md and Dockerfile for Quay.io

### DIFF
--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7
+FROM quay.io/centos7/s2i-core-centos7
 
 # MariaDB image for OpenShift.
 #
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb103,rh-mariadb103,galera" \
       com.redhat.component="rh-mariadb103-container" \
-      name="centos/mariadb-103-centos7" \
-      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mariadb-103-centos7" \
+      name="centos7/mariadb-103-centos7" \
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/centos7/mariadb-103-centos7" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306

--- a/10.3/root/usr/share/container-scripts/mysql/README.md
+++ b/10.3/root/usr/share/container-scripts/mysql/README.md
@@ -4,7 +4,7 @@ MariaDB 10.3 SQL Database Server Docker image
 This container image includes MariaDB 10.3 SQL database server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MariaDB SQL Database Server Docker Image
 ========================================
 
+MariaDB 10.3 Quay.io status: [![Docker Repository on Quay](https://quay.io/repository/centos7/mariadb-103-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/mariadb-103-centos7)
+
 This repository contains Dockerfiles for MariaDB images for OpenShift and general usage.
 Users can choose between RHEL, Fedora and CentOS based images.
 
@@ -57,7 +59,7 @@ Choose either the CentOS7 or RHEL7 based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/mariadb-103-centos7
+    $ podman pull quay.io/centos7/mariadb-103-centos7
     ```
 
     To build a CentOS based MariaDB image from scratch, run:


### PR DESCRIPTION
This commit adds support for Quay.io registry instead of Docker.io.

Docker.io introduces rate limit which block tests.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>