### PR TITLE
imagestream: point centos7 images to quay.io

### DIFF
--- a/imagestreams/mariadb-centos.json
+++ b/imagestreams/mariadb-centos.json
@@ -56,7 +56,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mariadb-103-centos7:latest"
+          "name": "quay.io/centos7/mariadb-103-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -74,7 +74,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mariadb-103-centos7:latest"
+          "name": "quay.io/centos7/mariadb-103-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Use quay.io as a source of the images to avoid Docker Hub ratelimiting where possible