### PR TITLE
Support testing on OpenShift-4

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -33,7 +33,7 @@ test_mariadb_integration "${IMAGE_NAME}"
 test_mariadb_imagestream
 
 if [[ "${OS}" =~ rhel7 ]] || [[ "${OS}" =~ centos7 ]] ; then
-  ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS}.json" "${THISDIR}/mariadb-ephemeral-template.json" mariadb
+  ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/mariadb-ephemeral-template.json" mariadb
 fi
 
 OS_TESTSUITE_RESULT=0

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -20,9 +20,11 @@ ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
+# For testing on OpenShift 4 we use external registry
+export CT_EXTERNAL_REGISTRY=true
+
+ct_os_set_ocp4
+
 
 # Check the template
 test_mariadb_integration "${IMAGE_NAME}"

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -45,7 +45,7 @@ function check_mysql_os_service_connection() {
 }
 
 function test_mysql_pure_image() {
-  local image_name=${1:-centos/mariadb-101-centos7}
+  local image_name=${1:-quay.io/centos7/mariadb-103-centos7}
   local image_name_no_namespace=${image_name##*/}
   local service_name="${image_name_no_namespace%%:*}-testing"
 
@@ -64,7 +64,7 @@ function test_mysql_pure_image() {
 }
 
 function test_mysql_template() {
-  local image_name=${1:-centos/mariadb-101-centos7}
+  local image_name=${1:-quay.io/centos7/mariadb-103-centos7}
   local image_name_no_namespace=${image_name##*/}
   local service_name="${image_name_no_namespace%%:*}-testing"
 
@@ -86,7 +86,7 @@ function test_mysql_template() {
 }
 
 function test_mysql_s2i() {
-  local image_name=${1:-centos/mariadb-101-centos7}
+  local image_name=${1:-quay.io/centos7/mariadb-103-centos7}
   local app=${2:-https://github.com/sclorg/mariadb-container.git}
   local context_dir=${3:-test/test-app}
   local image_name_no_namespace=${image_name##*/}
@@ -135,7 +135,7 @@ function test_mariadb_imagestream() {
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 
-  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS%%[0-9]*}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}"
+  ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}"
 }
 
 # Check the latest imagestreams

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -10,6 +10,7 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib.sh
 source ${THISDIR}/test-lib-openshift.sh
+source ${THISDIR}/test-lib-remote-openshift.sh
 
 function check_mysql_os_service_connection() {
   local util_image_name="${1}" ; shift

--- a/test/test-lib-remote-openshift.sh
+++ b/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../common/test-lib-remote-openshift.sh


### PR DESCRIPTION
This pull request adds the possibility to test mariadb-container on OpenShift 4 remote cluster
via the external registry, where is pushed the image after the build.