### PR TITLE
my.cnf: ignore netapp snapshot dir

### DIFF
--- a/root-common/etc/my.cnf
+++ b/root-common/etc/my.cnf
@@ -7,9 +7,12 @@ symbolic-links = 0
 skip_name_resolve
 
 # http://www.chriscalender.com/ignoring-the-lostfound-directory-in-your-datadir/
-ignore-db-dir=lost+found
+ignore-db-dirs=lost+found
 
 # GlusterFS equivalent of 'lost+found'
-ignore-db-dir=.trashcan
+ignore-db-dirs=.trashcan
+
+# NetApp snapshot dir
+ignore-db-dirs=.snapshot
 
 !includedir /etc/my.cnf.d


### PR DESCRIPTION
also expand ignore-db-dir to ignore-db-dirs otherwise startup complains:

[Note] Using unique option prefix 'ignore-db-dir' is error-prone and can break in the future. Please use the full name 'ignore_db_dirs' instead.
