### PR TITLE
Support building testing mariadb-container in CentOS Stream 9

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -8,8 +8,22 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        version: [10.3, 10.5]
+        include:
+          - version: "10.3"
+            dockerfile: "Dockerfile"
+            registry_namespace: "centos7"
+            tag: "centos7"
+          - version: "10.5"
+            dockerfile: "Dockerfile"
+            registry_namespace: "centos7"
+            tag: "centos7"
+          - version: "10.5"
+            dockerfile: "Dockerfile.c9s"
+            registry_namespace: "sclorg"
+            tag: "c9s"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -28,40 +42,58 @@ jobs:
           ver="${{ matrix.version }}"
           echo "::set-output name=SHORT_VER::${ver//./}"
 
-      - name: Check if dockerfile is present in version directory
-        id: check_dockerfile_file
+      - name: Login to Quay.io private registry
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
+      - name: Check if .exclude-${{ matrix.tag }} is present in version directory
+        id: check_exclude_file
         # https://github.com/marketplace/actions/file-existence
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ matrix.version }}/Dockerfile"
+          files: "${{ matrix.version }}/.exclude-${{ matrix.tag }}"
 
-      - name: Check if .exclude-centos7 is present in version directory
-        id: check_exclude_centos7_file
-        # https://github.com/marketplace/actions/file-existence
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/.exclude-centos7"
-
-      - name: Build CentOS7 image
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
+      - name: Build image
+        if: steps.check_exclude_file.outputs.files_exists == 'false'
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
         uses: redhat-actions/buildah-build@v2
         with:
-          dockerfiles: ${{ matrix.version }}/Dockerfile
-          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-centos7
-          tags: latest 1 ${{ github.sha }}
+          dockerfiles: ${{ matrix.version }}/${{ matrix.dockerfile }}
+          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-${{ matrix.tag }}
+          context: ${{ matrix.version }}
+          tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
-      - name: Push CentOS7 image to Quay.io
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false' && steps.check_dockerfile_file.outputs.files_exists == 'true'
-        id: push-to-quay
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace == 'centos7' }}
+        id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/centos7
+          registry: quay.io/${{ matrix.registry_namespace }}
           username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace != 'centos7' }}
+        id: push-to-quay-sclorg
+        uses: redhat-actions/push-to-registry@v2.2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/${{ matrix.registry_namespace }}
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN  }}
+
       - name: Print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        if: ${{ matrix.registry_namespace == 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-centos7.outputs.registry-paths }}"
+
+      - name: Print image url
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-sclorg.outputs.registry-paths }}"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build-and-push:
+    # To not run in forks
+    if: github.repository_owner == 'sclorg'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -69,7 +69,7 @@ jobs:
           tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
       - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
-        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace == 'centos7' }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace == 'centos7' }}
         id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
@@ -80,7 +80,7 @@ jobs:
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
       - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
-        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace != 'centos7' }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace != 'centos7' }}
         id: push-to-quay-sclorg
         uses: redhat-actions/push-to-registry@v2.2
         with:

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -1,0 +1,69 @@
+FROM quay.io/sclorg/s2i-core-c9s:c9s
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=10.5 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.5 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MariaDB 10.5" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
+      com.redhat.component="mariadb-105-container" \
+      name="sclorg/mariadb-105-c9s" \
+      version="1" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-105-c9s" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 10.5/root-common /
+COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.5/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]


### PR DESCRIPTION
This pull request adds support for building, testing, and pushing `mariadb-container` image
to CentOS Stream 9.

Container-common-scripts are updated.
`10.5/Dockerfile.c9s` docker file is added for building `mariadb-container` image for CentOS Stream 9.
`build-and-push.yml` file, as GitHub Action is updated to be able to push image into quay.io/sclorg/mariadb-105-c9s repository.

Dockefile.rhel8 and Dockerfile.c9s difference:
```bash
$ diff 10.5/Dockerfile.rhel8 10.5/Dockerfile.c9s
1c1
< FROM ubi8/s2i-core
---
> FROM quay.io/sclorg/s2i-core-c9s:c9s
29c29
<       name="rhel8/mariadb-105" \
---
>       name="sclorg/mariadb-105-c9s" \
31c31
<       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-105" \
---
>       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-105-c9s" \
39,40c39
< RUN yum -y module enable mariadb:$MYSQL_VERSION && \
<     INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
---
> RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
```