### PR TITLE
Build and push mariadb 10.5 image to quay.io/fedora/mariadb-105

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -49,6 +49,13 @@ jobs:
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             tag: "c8s"
             suffix: "c8s"
+          - dockerfile_path: "10.5"
+            dockerfile: "Dockerfile.fedora"
+            registry_namespace: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            tag: "fedora"
+
     steps:
       - name: Build and push to quay.io registry
         uses: sclorg/build-and-push-action@v2

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -55,6 +55,12 @@ jobs:
             quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             tag: "fedora"
+          - dockerfile_path: "10.3"
+            dockerfile: "Dockerfile.fedora"
+            registry_namespace: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            tag: "fedora"
 
     steps:
       - name: Build and push to quay.io registry

--- a/10.3/Dockerfile.fedora
+++ b/10.3/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f31/s2i-core:latest
+FROM quay.io/fedora/s2i-core:35
 
 # MariaDB image for OpenShift.
 #
@@ -29,9 +29,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb103,galera" \
       com.redhat.component="$NAME" \
-      name="$FGC/$NAME" \
+      name="fedora/$NAME-103" \
       version="$VERSION" \
-      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 $FGC/$NAME" \
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/fedora/$NAME-103" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -39,7 +39,8 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base mariadb mariadb-server policycoreutils" && \
+RUN yum -y module enable mariadb:$MYSQL_VERSION && \
+    INSTALL_PKGS="rsync tar gettext hostname bind-utils groff-base mariadb mariadb-server policycoreutils" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all && \

--- a/10.5/Dockerfile.fedora
+++ b/10.5/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f33/s2i-core:latest
+FROM quay.io/fedora/s2i-core:35
 
 # MariaDB image for OpenShift.
 #
@@ -29,9 +29,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb105,galera" \
       com.redhat.component="$NAME" \
-      name="$FGC/$NAME" \
+      name="fedora/$NAME-105" \
       version="$VERSION" \
-      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 $FGC/$NAME" \
+      usage="docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/fedora/$NAME-105" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@ MariaDB SQL Database Server Docker Image
 
 [![Build and push images to Quay.io registry](https://github.com/sclorg/mariadb-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/mariadb-container/actions/workflows/build-and-push.yml)
 
-MariaDB 10.3 Quay.io status: [![Docker Repository on Quay](https://quay.io/repository/centos7/mariadb-103-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/mariadb-103-centos7)
-MariaDB 10.5 Quay.io status: [![Docker Repository on Quay](https://quay.io/repository/centos7/mariadb-105-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/mariadb-105-centos7)
-
 This repository contains Dockerfiles for MariaDB images for OpenShift and general usage.
 Users can choose between RHEL, Fedora and CentOS based images.
 

--- a/test/run
+++ b/test/run
@@ -457,7 +457,7 @@ function run_tests() {
 
 run_doc_test() {
   echo "  Testing documentation in the container image"
-  ct_doc_content_old "MYSQL\_ROOT\_PASSWORD" volume 3306
+  ct_doc_content_old 'MYSQL\\?_ROOT\\?_PASSWORD' volume 3306
   echo "  Success!"
   echo
 }


### PR DESCRIPTION
This pull request builds and pushes mariadb-10.5 container to registry
`quay.io/fedora/mariadb-105`.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>