### PR TITLE
Support building, testing and pushing mariadb for CentOS Stream 8

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,21 +20,38 @@ jobs:
             quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
             tag: "centos7"
+            suffix: "centos7"
           - dockerfile_path: "10.5"
             dockerfile: "Dockerfile"
             registry_namespace: "centos7"
             quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
             tag: "centos7"
+            suffix: "centos7"
           - dockerfile_path: "10.5"
             dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             tag: "c9s"
+            suffix: "c9s"
+          - dockerfile_path: "10.5"
+            dockerfile: "Dockerfile.c8s"
+            registry_namespace: "sclorg"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            tag: "c8s"
+            suffix: "c8s"
+          - dockerfile_path: "10.3"
+            dockerfile: "Dockerfile.c8s"
+            registry_namespace: "sclorg"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            tag: "c8s"
+            suffix: "c8s"
     steps:
       - name: Build and push to quay.io registry
-        uses: sclorg/build-and-push-action@v1
+        uses: sclorg/build-and-push-action@v2
         with:
           registry: "quay.io"
           registry_namespace: ${{ matrix.registry_namespace }}
@@ -43,3 +60,4 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           dockerfile_path: ${{ matrix.dockerfile_path }}
           tag: ${{ matrix.tag }}
+          suffix: ${{ matrix.suffix }}

--- a/10.3/Dockerfile.c8s
+++ b/10.3/Dockerfile.c8s
@@ -1,0 +1,70 @@
+FROM quay.io/sclorg/s2i-core-c8s:c8s
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=10.3 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.3 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MariaDB 10.3" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb103,mariadb-103" \
+      com.redhat.component="mariadb-103-container" \
+      name="sclorg/mariadb-103-c8s" \
+      version="1" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-103-c8s" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum -y module enable mariadb:$MYSQL_VERSION && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 10.3/root-common /
+COPY 10.3/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.3/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/10.3/root/usr/share/container-scripts/mysql/README.md
+++ b/10.3/root/usr/share/container-scripts/mysql/README.md
@@ -4,7 +4,8 @@ MariaDB 10.3 SQL Database Server Docker image
 This container image includes MariaDB 10.3 SQL database server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS images are available on [Quay.io/centos7](https://quay.io/organization/centos7),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -362,4 +363,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
 In that repository, the Dockerfile for CentOS is called Dockerfile, the Dockerfile
 for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/10.5/Dockerfile.c8s
+++ b/10.5/Dockerfile.c8s
@@ -1,0 +1,70 @@
+FROM quay.io/sclorg/s2i-core-c8s:c8s
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=10.5 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.5 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MariaDB 10.5" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
+      com.redhat.component="mariadb-105-container" \
+      name="sclorg/mariadb-105-c8s" \
+      version="1" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-105-c8s" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum -y module enable mariadb:$MYSQL_VERSION && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 10.5/root-common /
+COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.5/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/10.5/root/usr/share/container-scripts/mysql/README.md
+++ b/10.5/root/usr/share/container-scripts/mysql/README.md
@@ -4,7 +4,8 @@ MariaDB 10.5 SQL Database Server Docker image
 This container image includes MariaDB 10.5 SQL database server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS images are available on [Quay.io/centos7](https://quay.io/organization/centos7),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -362,4 +363,6 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
 In that repository, the Dockerfile for CentOS is called Dockerfile, the Dockerfile
 for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS7
+* CentOS Stream 8
+* CentOS Stream 9
 
 
 Installation


### PR DESCRIPTION
This pull request adds support for building, pushing and testing
mariadb container in CentOS Stream 8.

* 10.3/Dockerfile.c8s is added
* 10.5/Dockerfile.c8s is added
* README.md files are updated

Differences between Dockerfile.rhel8 and Dockerfile.c8s:

```bash
diff 10.3/Dockerfile.rhel8 10.3/Dockerfile.c8s
1c1
< FROM ubi8/s2i-core
---
> FROM quay.io/sclorg/s2i-core-c8s:c8s
29c29
<       name="rhel8/mariadb-103" \
---
>       name="sclorg/mariadb-103-c8s" \
31c31
<       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-103" \
---
>       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-103-c8s" \
```