### PR TITLE
Support build and test maridb-container on RHEL9

### DIFF
--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -1,0 +1,69 @@
+FROM ubi9/s2i-core
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=10.5 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    SUMMARY="MariaDB 10.5 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MariaDB 10.5" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
+      com.redhat.component="mariadb-105-container" \
+      name="rhel9/mariadb-105" \
+      version="1" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/mariadb-105" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 10.5/root-common /
+COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.5/root /
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/10.5/root/usr/share/container-scripts/mysql/README.md
+++ b/10.5/root/usr/share/container-scripts/mysql/README.md
@@ -6,7 +6,7 @@ Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
 the CentOS images are available on [Quay.io/centos7](https://quay.io/organization/centos7),
 the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
-and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
+and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments
@@ -363,6 +363,7 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
 In that repository, the Dockerfile for CentOS is called Dockerfile, the Dockerfile
 for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
 the Dockerfile for CentOS Stream 8 is called Dockerfile.c8s,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ MariaDB SQL Database Server Docker Image
 
 [![Build and push images to Quay.io registry](https://github.com/sclorg/mariadb-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/mariadb-container/actions/workflows/build-and-push.yml)
 
+Images available on Quay are:
+* CentOS 7 [mariadb-103](https://quay.io/repository/centos7/mariadb-103-centos7)
+* CentOS 7 [mariadb-105](https://quay.io/repository/centos7/mariadb-105-centos7)
+* CentOS Stream 8 [mariadb-103](https://quay.io/repository/sclorg/mariadb-103-c8s)
+* CentOS Stream 8 [mariadb-105](https://quay.io/repository/sclorg/mariadb-105-c8s)
+* CentOS Stream 9 [mariadb-105](https://quay.io/repository/sclorg/mariadb-105-c9s)
+* Fedora [mariadb-103](https://quay.io/repository/fedora/mariadb-103)
+* Fedora [mariadb-105](https://quay.io/repository/fedora/mariadb-105)
+
 This repository contains Dockerfiles for MariaDB images for OpenShift and general usage.
 Users can choose between RHEL, Fedora and CentOS based images.
 
@@ -27,6 +36,7 @@ MariaDB versions currently provided are:
 RHEL versions currently supported are:
 * RHEL7
 * RHEL8
+* RHEL9
 
 CentOS versions currently supported are:
 * CentOS7


### PR DESCRIPTION
This pull request adds support for building, and testing mariadb-container on the RHEL9 host.

It also updates documentation with link to quay.io and RHEL9 info.