### PR TITLE
This pull request allows to enable testing mariadb-container into CVP pipeline

### DIFF
--- a/test/examples
+++ b/test/examples
@@ -1,0 +1,1 @@
+../examples/

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -10,7 +10,8 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib-mysql.sh
+source "${THISDIR}/test-lib-mysql.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_mariadb_integration
@@ -25,6 +26,8 @@ ct_os_set_ocp4
 ct_os_check_compulsory_vars
 
 ct_os_check_login || exit 1
+
+ct_os_tag_image_for_cvp "mariadb"
 
 set -u
 

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -129,22 +129,14 @@ function test_mariadb_integration() {
 # Check the imagestream
 function test_mariadb_imagestream() {
   case ${OS} in
-    rhel7|centos7) ;;
+    rhel7|centos7|rhel8) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
   local tag="-el7"
   if [ "${OS}" == "rhel8" ]; then
     tag="-el8"
   fi
-  # Try pulling the image first to see if it is accessible
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
-  if docker pull "${PUBLIC_IMAGE_NAME}"; then
-    ct_os_test_image_stream_template "${THISDIR}/../imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/../examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}${tag}"
-  else
-    echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
-    # ignore possible failure of this test for centos images
-    [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
-  fi
+  ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}${tag}"
 }
 
 function test_mariadb_template() {

--- a/test/test-openshift.yaml
+++ b/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../common/test-openshift.yaml


### PR DESCRIPTION
* container-common-scripts are updated
* Couple fixes in test-lib-mysql.sh and run-remote-openshift script
* add examples and test-openshift.yaml symlinks to test directory