### PR TITLE
imagestreams/mariadb-centos: Update for C9S

### DIFF
--- a/imagestreams/mariadb-centos.json
+++ b/imagestreams/mariadb-centos.json
@@ -20,7 +20,61 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10.5-el7"
+          "name": "10.5-c9s"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.5-fc",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.5 (Fedora)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.5 database on Fedora. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.5"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay./fedora/mariadb-105:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.5-c9s",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.5 (CentOS 9 Stream)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.5 database on CentOS 9 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.5"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay./sclorg/mariadb-105-c9s:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.5-c8s",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.5 (CentOS 8 Stream)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.5 database on CentOS 8 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.5"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay./sclorg/mariadb-105-c8s:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -45,18 +99,54 @@
         }
       },
       {
-        "name": "10.3-el8",
+        "name": "10.5",
         "annotations": {
-          "openshift.io/display-name": "MariaDB 10.3 (CentOS 8)",
+          "openshift.io/display-name": "MariaDB 10.5",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB 10.3 database on CentOS 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "description": "Provides a MariaDB 10.5 database on CentOS 9 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.5"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay./sclorg/mariadb-105-c9s:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.3-fc",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.3 (Fedora)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.5 database on Fedora. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb",
           "version": "10.3"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/mariadb-103-centos8:latest"
+          "name": "quay./fedora/mariadb-103:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "10.3-c8s",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.3 (CentOS 8 Stream)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.5 database on CentOS 8 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.3"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay./sclorg/mariadb-103-c8s:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -85,14 +175,14 @@
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.3",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Provides a MariaDB 10.3 database on CentOS 7. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
+          "description": "Provides a MariaDB 10.3 database on CentOS 8 Stream. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.3/README.md.",
           "iconClass": "icon-mariadb",
           "tags": "database,mariadb,hidden",
           "version": "10.3"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/centos7/mariadb-103-centos7:latest"
+          "name": "quay./sclorg/mariadb-103-c8s:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Also switch to using the C8S image from quay.io for EL8 instead of pulling from docker.io, avoiding rate-limits.
