### PR TITLE
Migrate DeploymentConfig to Deployment

### DIFF
--- a/examples/mariadb-ephemeral-template.json
+++ b/examples/mariadb-ephemeral-template.json
@@ -61,40 +61,24 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "apps.openshift.io/v1",
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
-          "template.alpha.openshift.io/wait-for-ready": "true"
+          "template.alpha.openshift.io/wait-for-ready": "true",
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {
         "strategy": {
-          "type": "Recreate"
+          "type": "RollingUpdate"
         },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "mariadb"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "mariadb:${MARIADB_VERSION}",
-                "namespace": "${NAMESPACE}"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
         "replicas": 1,
         "selector": {
-          "name": "${DATABASE_SERVICE_NAME}"
+          "matchLabels": {
+            "name": "${DATABASE_SERVICE_NAME}"
+          }
         },
         "template": {
           "metadata": {

--- a/examples/mariadb-persistent-template.json
+++ b/examples/mariadb-persistent-template.json
@@ -78,40 +78,24 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "apps.openshift.io/v1",
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
-          "template.alpha.openshift.io/wait-for-ready": "true"
+          "template.alpha.openshift.io/wait-for-ready": "true",
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {
         "strategy": {
-          "type": "Recreate"
+          "type": "RollingUpdate"
         },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "mariadb"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "mariadb:${MARIADB_VERSION}",
-                "namespace": "${NAMESPACE}"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
         "replicas": 1,
         "selector": {
-          "name": "${DATABASE_SERVICE_NAME}"
+          "matchLabels": {
+            "name": "${DATABASE_SERVICE_NAME}"
+          }
         },
         "template": {
           "metadata": {

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -16,7 +16,7 @@ source "${THISDIR}/test-lib-remote-openshift.sh"
 TEST_LIST="\
 test_mariadb_integration
 test_mariadb_imagestream
-test_mariadb_template
+test_mariadb_templates
 run_latest_imagestreams
 "
 

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -116,11 +116,12 @@ function test_mariadb_integration() {
   local service_name=mariadb
   TEMPLATES="mariadb-ephemeral-template.json
   mariadb-persistent-template.json"
+  SHORT_VERSION="${VERSION//.}"
   for template in $TEMPLATES; do
     ct_os_test_template_app_func "${IMAGE_NAME}" \
                                  "${THISDIR}/${template}" \
                                  "${service_name}" \
-                                 "ct_os_check_cmd_internal '<SAME_IMAGE>' '${service_name}-testing' \"echo 'SELECT 42 as testval\g' | mysql --connect-timeout=15 -h <IP> testdb -utestu -ptestp\" '^42' 120" \
+                                 "ct_os_check_cmd_internal 'registry.redhat.io/${OS}/mariadb-${SHORT_VERSION}:latest' '${service_name}-testing' \"echo 'SELECT 42 as testval\g' | mysql --connect-timeout=15 -h <IP> testdb -utestu -ptestp\" '^42' 120" \
                                  "-p MARIADB_VERSION=${VERSION} \
                                   -p DATABASE_SERVICE_NAME="${service_name}-testing" \
                                   -p MYSQL_USER=testu \

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -140,9 +140,14 @@ function test_mariadb_imagestream() {
   ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/examples/mariadb-ephemeral-template.json" mariadb "-p MARIADB_VERSION=${VERSION}${tag}"
 }
 
-function test_mariadb_template() {
-  ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/mariadb-ephemeral-template.json" mariadb
+function test_mariadb_templates() {
+  TEMPLATES="mariadb-ephemeral-template.json
+  mariadb-persistent-template.json"
+  for template in $TEMPLATES; do
+    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/${template}" mariadb
+  done
 }
+
 
 # Check the latest imagestreams
 function run_latest_imagestreams() {


### PR DESCRIPTION
Migration DeploymentConfigs to Deployment

    See more info here:
    https://docs.openshift.com/container-platform/4.12/applications/deployments/what-deployments-are.html

    Since OPenShift 4.14 DeploymentConfigs are deprecated: https://access.redhat.com/articles/7041372

It also improves the tests with officially released image.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
