### PR TITLE
Add support for testing MariaDB 10.11 in sclorg pipeline.

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "10.3", "10.5" ]
+        version: [ "10.3", "10.5", "10.11" ]
         os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c9s", "c8s"]
         test_case: [ "container" ]
 

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "10.3", "10.5" ]
+        version: [ "10.3", "10.5", "10.11" ]
         os_test: [ "centos7", "rhel7", "rhel8", "rhel9"]
         test_case: [ "openshift-3", "openshift-4" ]
         exclude:


### PR DESCRIPTION
Add support for testing MariaDB 10.11 in sclorg pipeline.
Files that were modified are container-tests.yml and openshift-tests.yml

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
