### PR TITLE
Do not use dead symlink in repository

### DIFF
--- a/10.11/Dockerfile.c8s
+++ b/10.11/Dockerfile.c8s
@@ -53,6 +53,11 @@ COPY 10.11/root-common /
 COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.11/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.11/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -53,6 +53,11 @@ COPY 10.11/root-common /
 COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.11/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.11/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -55,6 +55,11 @@ COPY 10.11/root-common /
 COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.11/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -62,10 +67,6 @@ COPY 10.11/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -53,6 +53,11 @@ COPY 10.11/root-common /
 COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.11/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.11/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -53,6 +53,11 @@ COPY 10.11/root-common /
 COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.11/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.11/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.3/Dockerfile
+++ b/10.3/Dockerfile
@@ -61,6 +61,11 @@ COPY 10.3/root-common /
 COPY 10.3/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.3/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -68,10 +73,6 @@ COPY 10.3/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.3/Dockerfile.c8s
+++ b/10.3/Dockerfile.c8s
@@ -53,6 +53,11 @@ COPY 10.3/root-common /
 COPY 10.3/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.3/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.3/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.3/Dockerfile.fedora
+++ b/10.3/Dockerfile.fedora
@@ -56,6 +56,11 @@ COPY 10.3/root-common /
 COPY 10.3/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.3/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -63,10 +68,6 @@ COPY 10.3/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.3/Dockerfile.rhel7
+++ b/10.3/Dockerfile.rhel7
@@ -62,6 +62,11 @@ COPY 10.3/root-common /
 COPY 10.3/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.3/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -69,10 +74,6 @@ COPY 10.3/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.3/Dockerfile.rhel8
+++ b/10.3/Dockerfile.rhel8
@@ -53,6 +53,11 @@ COPY 10.3/root-common /
 COPY 10.3/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.3/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.3/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile
+++ b/10.5/Dockerfile
@@ -61,6 +61,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -68,10 +73,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile.c8s
+++ b/10.5/Dockerfile.c8s
@@ -53,6 +53,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -53,6 +53,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile.fedora
+++ b/10.5/Dockerfile.fedora
@@ -56,6 +56,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -63,10 +68,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile.rhel7
+++ b/10.5/Dockerfile.rhel7
@@ -62,6 +62,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -69,10 +74,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -53,6 +53,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -60,10 +65,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -52,6 +52,11 @@ COPY 10.5/root-common /
 COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
 COPY 10.5/root /
 
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup
 # script.
@@ -59,10 +64,6 @@ COPY 10.5/root /
 RUN rm -rf /etc/my.cnf.d/* && \
     /usr/libexec/container-setup && \
     rpm-file-permissions
-
-# Not using VOLUME statement since it's not working in OpenShift Online:
-# https://github.com/sclorg/httpd-container/issues/30
-# VOLUME ["/var/lib/mysql/data"]
 
 USER 27
 

--- a/s2i-common/bin/run
+++ b/s2i-common/bin/run
@@ -1,1 +1,0 @@
-/bin/run-mysqld


### PR DESCRIPTION
This pull request removes dead link from this upstream repository.

During the syncing source from upstream/GitLab repositories, the dead links are not sync bu
Testing Farm because security.
Therefore GitLab tests are failing because run script is missing.

Creating symlink in Dockerfile's solved this problem.

Similar pull request is here: https://github.com/sclorg/postgresql-container/pull/552