### PR TITLE
Add proper latest tag, allow check for latest imagestreams

### DIFF
--- a/imagestreams/mariadb-centos.json
+++ b/imagestreams/mariadb-centos.json
@@ -20,7 +20,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10.5-el9"
+          "name": "10.11-el9"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/mariadb-rhel-aarch64.json
+++ b/imagestreams/mariadb-rhel-aarch64.json
@@ -20,7 +20,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10.5-el8"
+          "name": "10.11-el8"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/mariadb-rhel.json
+++ b/imagestreams/mariadb-rhel.json
@@ -20,7 +20,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "10.5-el8"
+          "name": "10.11-el8"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -125,7 +125,7 @@ function test_mariadb_integration() {
     # This directory is cloned from TMT plan repo 'sclorg-tmt-plans'
     local devel_file="/root/sclorg-tmt-plans/devel_images"
     if [ -f "${devel_file}" ]; then
-      if grep -q "${OS}=postgresql-container=${VERSION}" "$devel_file" ; then
+      if grep -q "${OS}=mariadb-container=${VERSION}" "$devel_file" ; then
         echo "This version is currently developed, so skipping this test."
         return
       fi
@@ -157,7 +157,7 @@ function test_mariadb_imagestream() {
     # This directory is cloned from TMT plan repo 'sclorg-tmt-plans'
     local devel_file="/root/sclorg-tmt-plans/devel_images"
     if [ -f "${devel_file}" ]; then
-      if grep -q "${OS}=postgresql-container=${VERSION}" "$devel_file" ; then
+      if grep -q "${OS}=mariadb-container=${VERSION}" "$devel_file" ; then
         echo "This version is currently developed, so skipping this test."
         return
       fi
@@ -176,7 +176,7 @@ function test_mariadb_template() {
     # This directory is cloned from TMT plan repo 'sclorg-tmt-plans'
     local devel_file="/root/sclorg-tmt-plans/devel_images"
     if [ -f "${devel_file}" ]; then
-      if grep -q "${OS}=postgresql-container=${VERSION}" "$devel_file" ; then
+      if grep -q "${OS}=mariadb-container=${VERSION}" "$devel_file" ; then
         echo "This version is currently developed, so skipping this test."
         return
       fi
@@ -193,17 +193,6 @@ function test_mariadb_template() {
 # Check the latest imagestreams
 function run_latest_imagestreams() {
   local result=1
-  if [ "${OS}" != "rhel7" ]; then
-  # Check if the current version is already GA
-  # This directory is cloned from TMT plan repo 'sclorg-tmt-plans'
-  local devel_file="/root/sclorg-tmt-plans/devel_images"
-  if [ -f "${devel_file}" ]; then
-    if grep -q "${OS}=postgresql-container=${VERSION}" "$devel_file" ; then
-      echo "This version is currently developed, so skipping this test."
-      return
-    fi
-  fi
-  fi
   # Switch to root directory of a container
   echo "Testing the latest version in imagestreams"
   pushd "${THISDIR}/../.." >/dev/null || return 1


### PR DESCRIPTION
Fix check for devel image. There should not be postgresql-container but mariadb-container.

Allow check for the latest imagestreams

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
