### PR TITLE
Fix plugin directory in the config file

### DIFF
--- a/root-common/usr/share/container-scripts/mysql/pre-init/my-base.cnf.template
+++ b/root-common/usr/share/container-scripts/mysql/pre-init/my-base.cnf.template
@@ -1,5 +1,5 @@
 [mysqld]
 datadir = ${MYSQL_DATADIR}
 basedir = ${MYSQL_PREFIX}
-plugin-dir = ${MYSQL_PREFIX}/lib64/mysql/plugin
+plugin-dir = ${MYSQL_PREFIX}/lib64/mariadb/plugin
 


### PR DESCRIPTION
Attempt to install the plugin currently fails with:
```
$ echo "INSTALL PLUGIN sql_errlog SONAME 'sql_errlog';" | mysql -uroot
ERROR 1126 (HY000) at line 1: Can't open shared library '/usr/lib64/mysql/plugin/sql_errlog.so' (errno: 11, cannot open shared object file: No such file or directory)
```

It's not clear to me whether this file with path spec is still needed at all, especially in versions that do not have a build for SCL (if it was added for that reason at all). Maybe this `base.cnf` might be removed, but I didn't do proper analysis to be able to say that it's possible. So, applying minimal patch meanwhile.

@FaramosCZ found this issue, thanks for that.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
