### PR TITLE
This commit fixes original file /bin/run-mysqld to /usr/bin/run-mysqld.

### DIFF
--- a/10.11/Dockerfile.c8s
+++ b/10.11/Dockerfile.c8s
@@ -56,7 +56,7 @@ COPY 10.11/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -56,7 +56,7 @@ COPY 10.11/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -58,7 +58,7 @@ COPY 10.11/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -56,7 +56,7 @@ COPY 10.11/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -56,7 +56,7 @@ COPY 10.11/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.c8s
+++ b/10.5/Dockerfile.c8s
@@ -56,7 +56,7 @@ COPY 10.5/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -56,7 +56,7 @@ COPY 10.5/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.fedora
+++ b/10.5/Dockerfile.fedora
@@ -59,7 +59,7 @@ COPY 10.5/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.rhel7
+++ b/10.5/Dockerfile.rhel7
@@ -65,7 +65,7 @@ COPY 10.5/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -56,7 +56,7 @@ COPY 10.5/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -55,7 +55,7 @@ COPY 10.5/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup


### PR DESCRIPTION
This commit fixes original file /bin/run-mysqld to /usr/bin/run-mysqld.

The file /usr/bin/run-mysqld is copied from directory $VERSION/root-common where it is stored in subdirectory usr/bin/run-mysqld.

The file /bin/run-mysqld does not exist.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
