### PR TITLE
Add file show_all_imagestreams.py from container-common-scripts

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -21,7 +21,7 @@
         app_versions: ["10.3", "10.5"]
 
       - name: RHEL 8
-        app_versions: ["10.3", "10.5"]
+        app_versions: ["10.3", "10.5", "10.11"]
 
       - name: RHEL 9
         app_versions: ["10.5", "10.11"]
@@ -30,7 +30,7 @@
     latest: "10.11-el9"
     distros:
       - name: RHEL 8
-        app_versions: ["10.3", "10.5"]
+        app_versions: ["10.3", "10.5", "10.11" ]
 
       - name: RHEL 9
         app_versions: ["10.5", "10.11"]

--- a/imagestreams/mariadb-rhel-aarch64.json
+++ b/imagestreams/mariadb-rhel-aarch64.json
@@ -46,6 +46,24 @@
         }
       },
       {
+        "name": "10.11-el8",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.11 (RHEL 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.11 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.11/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.11"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel8/mariadb-1011:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "10.5-el9",
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.5 (RHEL 9)",

--- a/imagestreams/mariadb-rhel.json
+++ b/imagestreams/mariadb-rhel.json
@@ -82,6 +82,24 @@
         }
       },
       {
+        "name": "10.11-el8",
+        "annotations": {
+          "openshift.io/display-name": "MariaDB 10.11 (RHEL 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a MariaDB 10.11 database on RHEL 8. For more information about using this database image, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/tree/master/10.11/README.md.",
+          "iconClass": "icon-mariadb",
+          "tags": "database,mariadb",
+          "version": "10.11"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel8/mariadb-1011:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "10.5-el9",
         "annotations": {
           "openshift.io/display-name": "MariaDB 10.5 (RHEL 9)",

--- a/test/show_all_imagestreams.py
+++ b/test/show_all_imagestreams.py
@@ -1,0 +1,1 @@
+../common/show_all_imagestreams.py


### PR DESCRIPTION
This pull request only adds show_all_imagestreams.py so it is working.

The file `show_all_imagestreams.py` shows all available imagestreams for this container, that are specified
in the directory `imagestreams`.

The example output will be seen in the next comment.