### PR TITLE
Add testing mariadb Helm Charts in mariadb-container

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -39,7 +39,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff-base mariadb-server" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \

--- a/test/test_mariadb_helm_imagestreams.py
+++ b/test/test_mariadb_helm_imagestreams.py
@@ -1,0 +1,38 @@
+import os
+
+import pytest
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+class TestHelmRHELMariadbImageStreams:
+
+    def setup_method(self):
+        package_name = "mariadb-imagestreams"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/redhat"
+        )
+
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    @pytest.mark.parametrize(
+        "version,registry,expected",
+        [
+            ("10.11-el9", "registry.redhat.io/rhel9/mariadb-1011:latest", True),
+            ("10.11-el8", "registry.redhat.io/rhel8/mariadb-1011:latest", True),
+            ("10.5-el9", "registry.redhat.io/rhel9/mariadb-105:latest", True),
+            ("10.3-el8", "registry.redhat.io/rhel8/mariadb-103:latest", True),
+            ("10.5-el8", "registry.redhat.io/rhel8/mariadb-105:latest", True),
+        ],
+    )
+    def test_package_imagestream(self, version, registry, expected):
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/test/test_mariadb_helm_template.py
+++ b/test/test_mariadb_helm_template.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+from pathlib import Path
+
+from container_ci_suite.helm import HelmChartsAPI
+
+test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+
+
+class TestHelmMariaDBPersistent:
+
+    def setup_method(self):
+        package_name = "mariadb-persistent"
+        path = test_dir
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api.clone_helm_chart_repo(
+            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            subdir="charts/redhat"
+        )
+    def teardown_method(self):
+        self.hc_api.delete_project()
+
+    def test_package_persistent(self):
+        self.hc_api.package_name = "mariadb-imagestreams"
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation()
+        self.hc_api.package_name = "mariadb-persistent"
+        assert self.hc_api.helm_package()
+        assert self.hc_api.helm_installation(values={".mariadb_version": "10.5-el8", ".namespace": self.hc_api.namespace})
+        assert self.hc_api.is_pod_running(pod_name_prefix="mariadb")
+        assert self.hc_api.test_helm_chart(expected_str=["42", "testval"])


### PR DESCRIPTION
This pull request adds support for testing Helm Charts stored in https://github.com/sclorg/helm-charts repository