### PR TITLE
Add support for building and testing mariadb-container on RHEL10

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -44,7 +44,7 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -1,0 +1,74 @@
+FROM registry.stage.redhat.io/ubi10/s2i-core
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+ENV MYSQL_VERSION=10.11 \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mariadb \
+    VERSION=10.11 \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.11 SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="MariaDB $VERSION" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
+      com.redhat.component="$NAME-1011-container" \
+      name="rhel10/mariadb-1011" \
+      version="1" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/mariadb-1011" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff-base mariadb-server" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
+    dnf -y clean all --enablerepo='*' && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY 10.11/root-common /
+COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.11/root /
+
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -43,7 +43,7 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -15,7 +15,6 @@ ENV MYSQL_VERSION=10.11 \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     VERSION=10.11 \
-    ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \

--- a/10.11/root/usr/share/container-scripts/mysql/README.md
+++ b/10.11/root/usr/share/container-scripts/mysql/README.md
@@ -362,6 +362,7 @@ Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
 In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
 the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ MariaDB versions currently provided are:
 RHEL versions currently supported are:
 * RHEL8
 * RHEL9
+* RHEL10
 
 CentOS versions currently supported are:
 * CentOS Stream 9


### PR DESCRIPTION
The pull request is separated into two commits.

The first commit adds support for building and testing mariadb-container especially version '10.11' on RHEL10.
The second commit updates README.md file with RHEL10 support.


<!-- issue-commentator = {"comment-id":"2589473582"} -->



















































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2589499222","data":[{"id":"27d9a1c4-e57b-47d7-8682-d5f9af1a01d1","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":404.380539,"created":"2025-01-15T09:59:39.178216","updated":"2025-01-15T09:59:39.178230","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/27d9a1c4-e57b-47d7-8682-d5f9af1a01d1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/27d9a1c4-e57b-47d7-8682-d5f9af1a01d1/pipeline.log\">pipeline</a>"]},{"id":"1b389664-08fd-47a7-b1f4-a7c522b2ab58","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":442.95903,"created":"2025-01-15T09:59:48.007694","updated":"2025-01-15T09:59:48.007700","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1b389664-08fd-47a7-b1f4-a7c522b2ab58\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1b389664-08fd-47a7-b1f4-a7c522b2ab58/pipeline.log\">pipeline</a>"]},{"id":"f1618516-1b99-494e-a3cc-58bc58d2ead9","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":452.56227,"created":"2025-01-15T09:59:39.255820","updated":"2025-01-15T09:59:39.255827","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f1618516-1b99-494e-a3cc-58bc58d2ead9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f1618516-1b99-494e-a3cc-58bc58d2ead9/pipeline.log\">pipeline</a>"]},{"id":"6a6eac65-bc0e-4aa8-9314-cb355abe838c","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":759.149586,"created":"2025-01-15T09:59:47.680082","updated":"2025-01-15T09:59:47.680096","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6a6eac65-bc0e-4aa8-9314-cb355abe838c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6a6eac65-bc0e-4aa8-9314-cb355abe838c/pipeline.log\">pipeline</a>"]},{"id":"aa04af94-0e6c-43dc-993e-ef8b3fa06e73","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":900.06668,"created":"2025-01-15T09:59:39.679328","updated":"2025-01-15T09:59:39.679336","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa04af94-0e6c-43dc-993e-ef8b3fa06e73\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa04af94-0e6c-43dc-993e-ef8b3fa06e73/pipeline.log\">pipeline</a>"]},{"id":"4bef7e8e-4ec4-4c28-b106-7545c317de97","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1030.411556,"created":"2025-01-15T09:59:57.143342","updated":"2025-01-15T09:59:57.143350","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bef7e8e-4ec4-4c28-b106-7545c317de97\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bef7e8e-4ec4-4c28-b106-7545c317de97/pipeline.log\">pipeline</a>"]},{"id":"94b779c7-2caf-4be3-88e3-2ba245f2c5c7","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1086.45978,"created":"2025-01-15T09:59:40.862231","updated":"2025-01-15T09:59:40.862239","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/94b779c7-2caf-4be3-88e3-2ba245f2c5c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/94b779c7-2caf-4be3-88e3-2ba245f2c5c7/pipeline.log\">pipeline</a>"]},{"id":"1d6e3925-33c4-48ac-8dc6-f7950a28f0fc","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1129.427599,"created":"2025-01-15T09:59:58.697224","updated":"2025-01-15T09:59:58.697234","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d6e3925-33c4-48ac-8dc6-f7950a28f0fc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d6e3925-33c4-48ac-8dc6-f7950a28f0fc/pipeline.log\">pipeline</a>"]},{"id":"57f8a78b-0d39-48a3-bc17-09d3271df5af","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1159.069001,"created":"2025-01-15T09:59:39.174811","updated":"2025-01-15T09:59:39.174819","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/57f8a78b-0d39-48a3-bc17-09d3271df5af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/57f8a78b-0d39-48a3-bc17-09d3271df5af/pipeline.log\">pipeline</a>"]},{"id":"6278eac5-c149-4a0e-ab16-c5a7d54fccde","name":"RHEL8 - 10.3","runTime":1260.927268,"created":"2025-01-15T09:59:39.221340","updated":"2025-01-15T09:59:39.221349","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6278eac5-c149-4a0e-ab16-c5a7d54fccde\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6278eac5-c149-4a0e-ab16-c5a7d54fccde/pipeline.log\">pipeline</a>"]}]} -->