### PR TITLE
Enhance 'chown' call

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -44,7 +44,7 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql:0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.c8s
+++ b/10.11/Dockerfile.c8s
@@ -42,7 +42,7 @@ RUN yum -y module enable mariadb:$MYSQL_VERSION && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -42,7 +42,7 @@ RUN yum -y module enable mariadb:$MYSQL_VERSION && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -44,7 +44,7 @@ RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-ba
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -43,7 +43,7 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     dnf -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql:0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -42,7 +42,7 @@ RUN yum -y module enable mariadb:$MYSQL_VERSION && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -42,7 +42,7 @@ RUN yum -y module enable mariadb:$MYSQL_VERSION && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts


### PR DESCRIPTION
1) Use common ':' separator instead of unusual '.' one, as disscussed here:
   https://github.com/sclorg/mariadb-container/pull/262#discussion_r1916127433

2) Use the same data type in the whole expression,
   so either only integers '27:0' or preferably only strings 'mysql:root'
   as suggested here:
   https://github.com/sclorg/mariadb-container/pull/262#discussion_r1916424440