### PR TITLE
Fix helm chart tests caused by renaming

### DIFF
--- a/test/test_mariadb_shared_helm_imagestreams.py
+++ b/test/test_mariadb_shared_helm_imagestreams.py
@@ -11,9 +11,9 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELMariadbImageStreams:
 
     def setup_method(self):
-        package_name = "mariadb-imagestreams"
+        package_name = "redhat-mariadb-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_mariadb_shared_helm_template.py
+++ b/test/test_mariadb_shared_helm_template.py
@@ -11,7 +11,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmMariaDBPersistent:
 
     def setup_method(self):
-        package_name = "mariadb-persistent"
+        package_name = "redhat-mariadb-persistent"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
@@ -23,10 +23,10 @@ class TestHelmMariaDBPersistent:
         self.hc_api.delete_project()
 
     def test_package_persistent(self):
-        self.hc_api.package_name = "mariadb-imagestreams"
+        self.hc_api.package_name = "redhat-mariadb-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "mariadb-persistent"
+        self.hc_api.package_name = "redhat-mariadb-persistent"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(values={".mariadb_version": "10.5-el8", ".namespace": self.hc_api.namespace})
         assert self.hc_api.is_pod_running(pod_name_prefix="mariadb")


### PR DESCRIPTION
helmcharts. Added suffix 'redhat-'

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2650074608"} -->















































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2650094540","data":[{"id":"0366e487-a98c-49fc-9b1c-c4192811f187","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1422.875451,"created":"2025-02-11T08:58:36.896940","updated":"2025-02-11T08:58:36.896951","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0366e487-a98c-49fc-9b1c-c4192811f187\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0366e487-a98c-49fc-9b1c-c4192811f187/pipeline.log\">pipeline</a>"]},{"id":"a816b7ad-35a9-424a-8959-f213b46eea34","name":"RHEL10 - OpenShift 4 - 10.11","status":"complete","outcome":"error","runTime":4001.853451,"created":"2025-02-11T10:59:27.429860","updated":"2025-02-11T10:59:27.429866","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a816b7ad-35a9-424a-8959-f213b46eea34\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a816b7ad-35a9-424a-8959-f213b46eea34/pipeline.log\">pipeline</a>"]},{"id":"6ce263f6-643e-4cef-bd92-54519ce0f450","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1429.616115,"created":"2025-02-11T08:58:35.530088","updated":"2025-02-11T08:58:35.530097","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ce263f6-643e-4cef-bd92-54519ce0f450\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ce263f6-643e-4cef-bd92-54519ce0f450/pipeline.log\">pipeline</a>"]},{"id":"cd2abf89-62e4-4fe1-94fc-eee7c584a769","name":"RHEL9 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":4385.246588,"created":"2025-02-11T10:59:35.686208","updated":"2025-02-11T10:59:35.686215","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd2abf89-62e4-4fe1-94fc-eee7c584a769\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd2abf89-62e4-4fe1-94fc-eee7c584a769/pipeline.log\">pipeline</a>"]},{"id":"462237b3-5d64-4551-b380-185ec56a8179","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1584.231662,"created":"2025-02-11T08:58:33.865984","updated":"2025-02-11T08:58:33.865992","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/462237b3-5d64-4551-b380-185ec56a8179\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/462237b3-5d64-4551-b380-185ec56a8179/pipeline.log\">pipeline</a>"]},{"id":"071e529d-0aa3-4cd0-8ca2-287f16969743","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":1621.710238,"created":"2025-02-11T08:58:35.160374","updated":"2025-02-11T08:58:35.160380","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/071e529d-0aa3-4cd0-8ca2-287f16969743\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/071e529d-0aa3-4cd0-8ca2-287f16969743/pipeline.log\">pipeline</a>"]},{"id":"01b2c5d0-41be-448d-9ac1-5dd9e7b4a5bd","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1629.516737,"created":"2025-02-11T08:58:38.249168","updated":"2025-02-11T08:58:38.249174","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01b2c5d0-41be-448d-9ac1-5dd9e7b4a5bd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01b2c5d0-41be-448d-9ac1-5dd9e7b4a5bd/pipeline.log\">pipeline</a>"]},{"id":"894c4bb7-0a96-4462-815c-4957d53694ec","name":"RHEL8 - PyTest - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":4926.246225,"created":"2025-02-11T10:59:44.645539","updated":"2025-02-11T10:59:44.645545","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/894c4bb7-0a96-4462-815c-4957d53694ec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/894c4bb7-0a96-4462-815c-4957d53694ec/pipeline.log\">pipeline</a>"]},{"id":"bf08c530-a622-4b84-8047-81fb1cd8e425","name":"RHEL8 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":4963.817477,"created":"2025-02-11T10:59:39.026023","updated":"2025-02-11T10:59:39.026029","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf08c530-a622-4b84-8047-81fb1cd8e425\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf08c530-a622-4b84-8047-81fb1cd8e425/pipeline.log\">pipeline</a>"]},{"id":"9cdf6861-7615-4053-98d5-b864ecd13f81","name":"RHEL8 - PyTest - OpenShift 4 - 10.5","runTime":6158.329064,"created":"2025-02-11T11:00:33.224710","updated":"2025-02-11T11:00:33.224716","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cdf6861-7615-4053-98d5-b864ecd13f81\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cdf6861-7615-4053-98d5-b864ecd13f81/pipeline.log\">pipeline</a>"]},{"id":"6a8d6d5d-8fc2-46c1-8e83-78510364bdca","name":"RHEL10 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"error","runTime":4325.499773,"created":"2025-02-11T10:59:36.191585","updated":"2025-02-11T10:59:36.191590","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6a8d6d5d-8fc2-46c1-8e83-78510364bdca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6a8d6d5d-8fc2-46c1-8e83-78510364bdca/pipeline.log\">pipeline</a>"]},{"id":"72042b37-860c-4e68-9b96-572afc8b7115","name":"RHEL9 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":4400.38129,"created":"2025-02-11T10:59:29.980741","updated":"2025-02-11T10:59:29.980747","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/72042b37-860c-4e68-9b96-572afc8b7115\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/72042b37-860c-4e68-9b96-572afc8b7115/pipeline.log\">pipeline</a>"]}]} -->