### PR TITLE
Allow testing mariadb-container on OpenShift 4 shared cluster

### DIFF
--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM registry.stage.redhat.io/ubi10/s2i-core
+FROM ubi10/s2i-core
 
 # MariaDB image for OpenShift.
 #

--- a/test/test_mariadb_imagestream.py
+++ b/test/test_mariadb_imagestream.py
@@ -16,7 +16,8 @@ IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 TAGS = {
     "rhel8": "-el8",
-    "rhel9": "-el9"
+    "rhel9": "-el9",
+    "rhel10": "-el10",
 }
 TAG = TAGS.get(OS, None)
 
@@ -37,6 +38,8 @@ class TestMariaDBImagestreamTemplate:
         ]
     )
     def test_mariadb_imagestream_template(self, template):
+        if OS == "rhel10":
+            pytest.skip("Skipping test for rhel10")
         os_name = ''.join(i for i in OS if not i.isdigit())
         print(os.getcwd())
         assert self.oc_api.deploy_image_stream_template(

--- a/test/test_mariadb_imagestream.py
+++ b/test/test_mariadb_imagestream.py
@@ -24,7 +24,7 @@ TAG = TAGS.get(OS, None)
 class TestMariaDBImagestreamTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="mariadb", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="mariadb", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_mariadb_imagestream_template.py
+++ b/test/test_mariadb_imagestream_template.py
@@ -16,7 +16,8 @@ IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 TAGS = {
     "rhel8": "-el8",
-    "rhel9": "-el9"
+    "rhel9": "-el9",
+    "rhel10": "-el10"
 }
 TAG = TAGS.get(OS, None)
 
@@ -37,6 +38,8 @@ class TestMariaDBImagestreamTemplate:
         ]
     )
     def test_mariadb_imagestream_template(self, template):
+        if OS == "rhel10":
+            pytest.skip("Skipping test for rhel10")
         os_name = ''.join(i for i in OS if not i.isdigit())
         assert self.oc_api.deploy_image_stream_template(
             imagestream_file=f"imagestreams/mariadb-{os_name}.json",

--- a/test/test_mariadb_imagestream_template.py
+++ b/test/test_mariadb_imagestream_template.py
@@ -24,7 +24,7 @@ TAG = TAGS.get(OS, None)
 class TestMariaDBImagestreamTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="mariadb", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="mariadb", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_mariadb_local_template.py
+++ b/test/test_mariadb_local_template.py
@@ -17,7 +17,8 @@ OS = os.getenv("TARGET")
 
 TAGS = {
     "rhel8": "-el8",
-    "rhel9": "-el9"
+    "rhel9": "-el9",
+    "rhel10": "-el10",
 }
 TAG = TAGS.get(OS, None)
 
@@ -39,6 +40,8 @@ class TestMariaDBDeployTemplate:
         ]
     )
     def test_python_template_inside_cluster(self, template):
+        if OS == "rhel10":
+            pytest.skip("Skipping test for rhel10")
         short_version = VERSION.replace(".", "")
         assert self.oc_api.deploy_template_with_image(
             image_name=IMAGE_NAME,

--- a/test/test_mariadb_local_template.py
+++ b/test/test_mariadb_local_template.py
@@ -25,7 +25,7 @@ TAG = TAGS.get(OS, None)
 class TestMariaDBDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="mariadb-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="mariadb-testing", version=VERSION, shared_cluster=True)
         self.oc_api.import_is("imagestreams/mariadb-rhel.json", "", skip_check=True)
 
     def teardown_method(self):

--- a/test/test_mariadb_shared_helm_imagestreams.py
+++ b/test/test_mariadb_shared_helm_imagestreams.py
@@ -13,7 +13,7 @@ class TestHelmRHELMariadbImageStreams:
     def setup_method(self):
         package_name = "redhat-mariadb-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"


### PR DESCRIPTION
This pull request enables testing mariadb-container on OpenShift 4 shared cluster.

<!-- issue-commentator = {"comment-id":"2697255016"} -->







































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2697284331","data":[{"id":"63d70bce-aebd-454c-94f9-1e1eb9380a23","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":565.928864,"created":"2025-03-04T12:26:11.594304","updated":"2025-03-04T12:26:11.594311","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/63d70bce-aebd-454c-94f9-1e1eb9380a23\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/63d70bce-aebd-454c-94f9-1e1eb9380a23/pipeline.log\">pipeline</a>"]},{"id":"adf00371-a94f-471c-b035-3c1d54bed49a","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":545.159651,"created":"2025-03-04T12:38:12.538602","updated":"2025-03-04T12:38:12.538610","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/adf00371-a94f-471c-b035-3c1d54bed49a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/adf00371-a94f-471c-b035-3c1d54bed49a/pipeline.log\">pipeline</a>"]},{"id":"4e912575-220a-4436-93a7-8cea68312a56","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":628.585614,"created":"2025-03-04T12:26:21.284194","updated":"2025-03-04T12:26:21.284203","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4e912575-220a-4436-93a7-8cea68312a56\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4e912575-220a-4436-93a7-8cea68312a56/pipeline.log\">pipeline</a>"]},{"id":"c44b2214-7d0c-4388-816b-56474bbe5db7","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":686.574825,"created":"2025-03-04T11:44:14.081593","updated":"2025-03-04T11:44:14.081598","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c44b2214-7d0c-4388-816b-56474bbe5db7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c44b2214-7d0c-4388-816b-56474bbe5db7/pipeline.log\">pipeline</a>"]},{"id":"58653df4-9d19-435e-8a43-e463c197c075","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":2590.488401,"created":"2025-03-04T12:41:08.778491","updated":"2025-03-04T12:41:08.778498","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58653df4-9d19-435e-8a43-e463c197c075\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58653df4-9d19-435e-8a43-e463c197c075/pipeline.log\">pipeline</a>"]},{"id":"a6ceb668-3d1d-437f-afe3-f7b18cb48eb8","name":"RHEL10 - OpenShift 4 - 10.11","runTime":2527.493096,"created":"2025-03-04T14:20:40.458410","updated":"2025-03-04T14:20:40.458416","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6ceb668-3d1d-437f-afe3-f7b18cb48eb8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6ceb668-3d1d-437f-afe3-f7b18cb48eb8/pipeline.log\">pipeline</a>"]},{"id":"6076daf0-826a-461a-abf5-6467e7d6eea3","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":3069.466021,"created":"2025-03-04T12:33:53.914386","updated":"2025-03-04T12:33:53.914395","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6076daf0-826a-461a-abf5-6467e7d6eea3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6076daf0-826a-461a-abf5-6467e7d6eea3/pipeline.log\">pipeline</a>"]},{"id":"f83a54d5-d90d-452b-8bd3-2b0541f4efb6","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":3253.06626,"created":"2025-03-04T12:27:17.469836","updated":"2025-03-04T12:27:17.469843","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f83a54d5-d90d-452b-8bd3-2b0541f4efb6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f83a54d5-d90d-452b-8bd3-2b0541f4efb6/pipeline.log\">pipeline</a>"]},{"id":"45c0c320-a913-4370-bffe-6a15c81a08f4","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":2493.33612,"created":"2025-03-04T12:45:19.927479","updated":"2025-03-04T12:45:19.927486","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45c0c320-a913-4370-bffe-6a15c81a08f4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45c0c320-a913-4370-bffe-6a15c81a08f4/pipeline.log\">pipeline</a>"]},{"id":"833d3235-2882-45c2-ac65-0f1db616c527","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1040.485244,"created":"2025-03-04T14:20:43.170434","updated":"2025-03-04T14:20:43.170441","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/833d3235-2882-45c2-ac65-0f1db616c527\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/833d3235-2882-45c2-ac65-0f1db616c527/pipeline.log\">pipeline</a>"]},{"id":"5e218446-35be-4296-88a6-4db34578a748","name":"RHEL9 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1194.207581,"created":"2025-03-04T14:20:42.080846","updated":"2025-03-04T14:20:42.080853","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e218446-35be-4296-88a6-4db34578a748\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e218446-35be-4296-88a6-4db34578a748/pipeline.log\">pipeline</a>"]},{"id":"c843ec86-07c1-47c0-a5bd-6fdce47072b2","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":3347.825671,"created":"2025-03-04T12:29:20.688764","updated":"2025-03-04T12:29:20.688771","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c843ec86-07c1-47c0-a5bd-6fdce47072b2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c843ec86-07c1-47c0-a5bd-6fdce47072b2/pipeline.log\">pipeline</a>"]},{"id":"879ab26d-6d59-49f4-99cf-18ec621eba93","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":3090.717323,"created":"2025-03-04T12:36:24.642455","updated":"2025-03-04T12:36:24.642470","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/879ab26d-6d59-49f4-99cf-18ec621eba93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/879ab26d-6d59-49f4-99cf-18ec621eba93/pipeline.log\">pipeline</a>"]},{"id":"ebd7d215-763f-4a24-8adc-060e26bf2e81","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1204.860365,"created":"2025-03-04T14:20:40.601889","updated":"2025-03-04T14:20:40.601896","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebd7d215-763f-4a24-8adc-060e26bf2e81\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebd7d215-763f-4a24-8adc-060e26bf2e81/pipeline.log\">pipeline</a>"]},{"id":"caa09140-b9aa-418f-8b64-1ef67582500a","name":"RHEL9 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1077.862301,"created":"2025-03-04T14:20:42.049031","updated":"2025-03-04T14:20:42.049037","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/caa09140-b9aa-418f-8b64-1ef67582500a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/caa09140-b9aa-418f-8b64-1ef67582500a/pipeline.log\">pipeline</a>"]},{"id":"c3d00c7d-04f3-4822-ab6d-cfea3c7940dd","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":1177.674257,"created":"2025-03-04T14:20:42.160235","updated":"2025-03-04T14:20:42.160243","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3d00c7d-04f3-4822-ab6d-cfea3c7940dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3d00c7d-04f3-4822-ab6d-cfea3c7940dd/pipeline.log\">pipeline</a>"]},{"id":"9998c6aa-0aca-4e8e-94ec-9ea917bd23ff","name":"RHEL8 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1236.449181,"created":"2025-03-04T14:20:42.953860","updated":"2025-03-04T14:20:42.953866","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9998c6aa-0aca-4e8e-94ec-9ea917bd23ff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9998c6aa-0aca-4e8e-94ec-9ea917bd23ff/pipeline.log\">pipeline</a>"]},{"id":"f4509163-43ed-43f3-bdb5-7102b4063e6e","name":"RHEL8 - PyTest - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":1256.922975,"created":"2025-03-04T14:20:42.762876","updated":"2025-03-04T14:20:42.762882","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4509163-43ed-43f3-bdb5-7102b4063e6e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4509163-43ed-43f3-bdb5-7102b4063e6e/pipeline.log\">pipeline</a>"]},{"id":"0378683f-ff2e-489b-a080-aa6ddf2af2e5","name":"RHEL8 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1272.563051,"created":"2025-03-04T14:20:41.612462","updated":"2025-03-04T14:20:41.612469","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0378683f-ff2e-489b-a080-aa6ddf2af2e5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0378683f-ff2e-489b-a080-aa6ddf2af2e5/pipeline.log\">pipeline</a>"]},{"id":"093a7aed-5be2-44c4-8e3c-c8f7fee16e9d","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1023.506602,"created":"2025-03-04T14:20:41.591836","updated":"2025-03-04T14:20:41.591843","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/093a7aed-5be2-44c4-8e3c-c8f7fee16e9d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/093a7aed-5be2-44c4-8e3c-c8f7fee16e9d/pipeline.log\">pipeline</a>"]},{"id":"50dbe041-e91e-45e8-8a6d-674eb12d84b5","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1163.13726,"created":"2025-03-04T14:20:43.432841","updated":"2025-03-04T14:20:43.432848","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/50dbe041-e91e-45e8-8a6d-674eb12d84b5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/50dbe041-e91e-45e8-8a6d-674eb12d84b5/pipeline.log\">pipeline</a>"]},{"id":"0545a7a6-2d4e-4fa0-aefe-eee3b82d0c1c","name":"RHEL10 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":813.330571,"created":"2025-03-04T14:20:43.004875","updated":"2025-03-04T14:20:43.004882","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0545a7a6-2d4e-4fa0-aefe-eee3b82d0c1c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0545a7a6-2d4e-4fa0-aefe-eee3b82d0c1c/pipeline.log\">pipeline</a>"]}]} -->