### PR TITLE
Rename package bind-utils to bind9.18-utils

### DIFF
--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -37,7 +37,7 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable mariadb:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind9.18-utils groff-base mariadb-server" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -36,7 +36,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base mariadb-server" && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind9.18-utils groff-base mariadb-server" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \


### PR DESCRIPTION
Rename package bind-utils to bind9.18-utils

See Jira Ticket: https://issues.redhat.com/browse/RHEL-80345

<!-- issue-commentator = {"comment-id":"2740740593"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2742970283","data":[{"id":"2b89debe-76fa-4b9b-8713-599612f2b708","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":401.735635,"created":"2025-03-21T10:28:45.681012","updated":"2025-03-21T10:28:45.681019","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2b89debe-76fa-4b9b-8713-599612f2b708\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2b89debe-76fa-4b9b-8713-599612f2b708/pipeline.log\">pipeline</a>"]},{"id":"0d9b777f-b3a9-4720-8f85-6a318b7452ea","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":445.402833,"created":"2025-03-21T10:28:36.335725","updated":"2025-03-21T10:28:36.335732","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0d9b777f-b3a9-4720-8f85-6a318b7452ea\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0d9b777f-b3a9-4720-8f85-6a318b7452ea/pipeline.log\">pipeline</a>"]},{"id":"811a9e30-9ebf-4081-93d8-5481668dfab3","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":429.817874,"created":"2025-03-21T10:28:35.684131","updated":"2025-03-21T10:28:35.684139","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/811a9e30-9ebf-4081-93d8-5481668dfab3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/811a9e30-9ebf-4081-93d8-5481668dfab3/pipeline.log\">pipeline</a>"]},{"id":"b0ed3199-af6d-4722-98d8-8cf64cdb62ea","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":542.329828,"created":"2025-03-21T10:28:46.406596","updated":"2025-03-21T10:28:46.406605","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b0ed3199-af6d-4722-98d8-8cf64cdb62ea\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b0ed3199-af6d-4722-98d8-8cf64cdb62ea/pipeline.log\">pipeline</a>"]},{"id":"7ba2f368-a7d6-426f-9db5-a180224bdb1f","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1223.20413,"created":"2025-03-21T13:14:09.372922","updated":"2025-03-21T13:14:09.372930","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ba2f368-a7d6-426f-9db5-a180224bdb1f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ba2f368-a7d6-426f-9db5-a180224bdb1f/pipeline.log\">pipeline</a>"]},{"id":"58288462-e995-4d14-8e73-f58403d383b8","name":"RHEL8 - OpenShift 4 - 10.3","runTime":1717.297519,"created":"2025-03-21T13:14:09.045674","updated":"2025-03-21T13:14:09.045683","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58288462-e995-4d14-8e73-f58403d383b8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58288462-e995-4d14-8e73-f58403d383b8/pipeline.log\">pipeline</a>"]},{"id":"55e8bce4-f824-4131-9d66-f0fd6a7d354d","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1082.561751,"created":"2025-03-21T12:36:32.587832","updated":"2025-03-21T12:36:32.587839","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55e8bce4-f824-4131-9d66-f0fd6a7d354d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55e8bce4-f824-4131-9d66-f0fd6a7d354d/pipeline.log\">pipeline</a>"]},{"id":"972a48e1-375f-4b0c-8c6c-af96db8d2b09","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1133.007615,"created":"2025-03-21T12:36:32.568042","updated":"2025-03-21T12:36:32.568051","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/972a48e1-375f-4b0c-8c6c-af96db8d2b09\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/972a48e1-375f-4b0c-8c6c-af96db8d2b09/pipeline.log\">pipeline</a>"]},{"id":"a7f63f1d-fccc-429f-ab70-097603c2dfd3","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1302.80631,"created":"2025-03-21T13:14:10.547044","updated":"2025-03-21T13:14:10.547050","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7f63f1d-fccc-429f-ab70-097603c2dfd3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7f63f1d-fccc-429f-ab70-097603c2dfd3/pipeline.log\">pipeline</a>"]},{"id":"5103b45d-e915-4767-b99c-e0514d973f4e","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":860.200656,"created":"2025-03-21T10:28:38.248245","updated":"2025-03-21T10:28:38.248255","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5103b45d-e915-4767-b99c-e0514d973f4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5103b45d-e915-4767-b99c-e0514d973f4e/pipeline.log\">pipeline</a>"]},{"id":"3ea3d1e9-6b0d-46aa-bafc-84ee79b48920","name":"RHEL10 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":692.082844,"created":"2025-03-21T10:32:03.699234","updated":"2025-03-21T10:32:03.699240","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ea3d1e9-6b0d-46aa-bafc-84ee79b48920\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ea3d1e9-6b0d-46aa-bafc-84ee79b48920/pipeline.log\">pipeline</a>"]},{"id":"0e0dcdb7-9cc5-4429-a4ac-225ffac85397","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":886.877332,"created":"2025-03-21T10:28:44.521772","updated":"2025-03-21T10:28:44.521780","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e0dcdb7-9cc5-4429-a4ac-225ffac85397\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e0dcdb7-9cc5-4429-a4ac-225ffac85397/pipeline.log\">pipeline</a>"]},{"id":"cbac332e-5302-4b06-bf98-359a2fd4f5c0","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":910.036735,"created":"2025-03-21T10:28:35.722279","updated":"2025-03-21T10:28:35.722288","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cbac332e-5302-4b06-bf98-359a2fd4f5c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cbac332e-5302-4b06-bf98-359a2fd4f5c0/pipeline.log\">pipeline</a>"]},{"id":"0079438e-a141-4ece-b6c4-d1756c40a946","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1011.791959,"created":"2025-03-21T10:29:02.555038","updated":"2025-03-21T10:29:02.555045","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0079438e-a141-4ece-b6c4-d1756c40a946\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0079438e-a141-4ece-b6c4-d1756c40a946/pipeline.log\">pipeline</a>"]},{"id":"208cbb1d-8d97-4948-ad7d-78c3ea5a90bd","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1004.822334,"created":"2025-03-21T10:33:01.569060","updated":"2025-03-21T10:33:01.569067","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/208cbb1d-8d97-4948-ad7d-78c3ea5a90bd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/208cbb1d-8d97-4948-ad7d-78c3ea5a90bd/pipeline.log\">pipeline</a>"]},{"id":"a8692662-21de-4800-b7d0-1cded7c0f74b","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1149.995018,"created":"2025-03-21T12:36:32.455470","updated":"2025-03-21T12:36:32.455477","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8692662-21de-4800-b7d0-1cded7c0f74b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8692662-21de-4800-b7d0-1cded7c0f74b/pipeline.log\">pipeline</a>"]}]} -->