### PR TITLE
[licensing] Add license specification for RHEL and CS images

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -32,6 +32,7 @@ LABEL summary="${SUMMARY}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c10s" \
       version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c10s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -31,6 +31,7 @@ LABEL summary="${SUMMARY}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
       version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -32,6 +32,7 @@ LABEL summary="${SUMMARY}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
       version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -31,6 +31,7 @@ LABEL summary="${SUMMARY}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
       version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -31,6 +31,7 @@ LABEL summary="${SUMMARY}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
       version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -31,6 +31,7 @@ LABEL summary="${SUMMARY}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
       version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 


### PR DESCRIPTION
<!-- issue-commentator = {"comment-id":"2787052123"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2787346274","data":[{"id":"2389ebce-b6a9-4d53-8fb5-2cb82114ed21","name":"RHEL10 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":5545.250432,"created":"2025-04-08T17:01:27.945971","updated":"2025-04-08T17:01:27.945980","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2389ebce-b6a9-4d53-8fb5-2cb82114ed21\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2389ebce-b6a9-4d53-8fb5-2cb82114ed21/pipeline.log\">pipeline</a>"]},{"id":"994dfd5c-190b-4aad-9c04-6832a64e876d","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":5757.474296,"created":"2025-04-08T17:01:27.295465","updated":"2025-04-08T17:01:27.295471","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/994dfd5c-190b-4aad-9c04-6832a64e876d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/994dfd5c-190b-4aad-9c04-6832a64e876d/pipeline.log\">pipeline</a>"]},{"id":"2bfbc5ea-d7ce-497d-b8ad-66972fe42b37","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":5777.34312,"created":"2025-04-08T17:01:28.810186","updated":"2025-04-08T17:01:28.810196","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2bfbc5ea-d7ce-497d-b8ad-66972fe42b37\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2bfbc5ea-d7ce-497d-b8ad-66972fe42b37/pipeline.log\">pipeline</a>"]},{"id":"da34f019-e92f-4f12-b66d-201361f2a306","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":5847.692719,"created":"2025-04-08T17:01:27.500094","updated":"2025-04-08T17:01:27.500100","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da34f019-e92f-4f12-b66d-201361f2a306\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da34f019-e92f-4f12-b66d-201361f2a306/pipeline.log\">pipeline</a>"]},{"id":"a33aa405-44d6-4263-a0df-92cf9532ca51","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":5861.133896,"created":"2025-04-08T17:01:28.708729","updated":"2025-04-08T17:01:28.708734","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a33aa405-44d6-4263-a0df-92cf9532ca51\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a33aa405-44d6-4263-a0df-92cf9532ca51/pipeline.log\">pipeline</a>"]},{"id":"90dd9d00-4a42-4a1e-bfb8-1ac0059f6049","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":6011.591901,"created":"2025-04-08T17:01:28.189497","updated":"2025-04-08T17:01:28.189504","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/90dd9d00-4a42-4a1e-bfb8-1ac0059f6049\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/90dd9d00-4a42-4a1e-bfb8-1ac0059f6049/pipeline.log\">pipeline</a>"]},{"id":"8d7f4159-e343-44c2-aa6f-312798982384","name":"RHEL10 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":8497.708587,"created":"2025-04-08T17:01:28.931272","updated":"2025-04-08T17:01:28.931278","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d7f4159-e343-44c2-aa6f-312798982384\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d7f4159-e343-44c2-aa6f-312798982384/pipeline.log\">pipeline</a>"]},{"id":"8202393e-669e-485d-988a-20651ecc95b9","name":"RHEL9 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":8650.586173,"created":"2025-04-08T17:01:28.751471","updated":"2025-04-08T17:01:28.751479","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8202393e-669e-485d-988a-20651ecc95b9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8202393e-669e-485d-988a-20651ecc95b9/pipeline.log\">pipeline</a>"]},{"id":"9c67f3b0-af10-4373-b062-0a23307142dd","name":"RHEL9 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":8690.623501,"created":"2025-04-08T17:01:28.358172","updated":"2025-04-08T17:01:28.358177","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c67f3b0-af10-4373-b062-0a23307142dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c67f3b0-af10-4373-b062-0a23307142dd/pipeline.log\">pipeline</a>"]},{"id":"82ae2688-4ef7-485f-8488-6ef7026bcbec","name":"RHEL8 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":9064.989656,"created":"2025-04-08T17:01:28.261201","updated":"2025-04-08T17:01:28.261208","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/82ae2688-4ef7-485f-8488-6ef7026bcbec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/82ae2688-4ef7-485f-8488-6ef7026bcbec/pipeline.log\">pipeline</a>"]},{"id":"208896f0-e876-4cfe-bb57-eafdd6275cb1","name":"RHEL8 - PyTest - OpenShift 4 - 10.11","runTime":14052.44793,"created":"2025-04-11T06:46:37.763013","updated":"2025-04-11T06:46:37.763019","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/208896f0-e876-4cfe-bb57-eafdd6275cb1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/208896f0-e876-4cfe-bb57-eafdd6275cb1/pipeline.log\">pipeline</a>"]},{"id":"c1eb1eea-0120-40d9-94d4-adbbbb780c9c","name":"RHEL8 - PyTest - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":9495.515544,"created":"2025-04-08T17:01:29.782271","updated":"2025-04-08T17:01:29.782305","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c1eb1eea-0120-40d9-94d4-adbbbb780c9c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c1eb1eea-0120-40d9-94d4-adbbbb780c9c/pipeline.log\">pipeline</a>"]},{"id":"3d8391fc-dc02-42b1-a82f-71f6e26bc804","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":400.168633,"created":"2025-04-09T07:49:05.111557","updated":"2025-04-09T07:49:05.111563","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3d8391fc-dc02-42b1-a82f-71f6e26bc804\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3d8391fc-dc02-42b1-a82f-71f6e26bc804/pipeline.log\">pipeline</a>"]},{"id":"43df9e4b-71e8-4f4a-96d9-369f12351b9c","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":432.72022,"created":"2025-04-09T07:49:05.169866","updated":"2025-04-09T07:49:05.169872","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/43df9e4b-71e8-4f4a-96d9-369f12351b9c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/43df9e4b-71e8-4f4a-96d9-369f12351b9c/pipeline.log\">pipeline</a>"]},{"id":"0b75143c-8011-419e-9159-f0ebfe8b7ad2","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":430.822515,"created":"2025-04-09T07:49:04.929511","updated":"2025-04-09T07:49:04.929518","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0b75143c-8011-419e-9159-f0ebfe8b7ad2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0b75143c-8011-419e-9159-f0ebfe8b7ad2/pipeline.log\">pipeline</a>"]},{"id":"a296e05c-eb70-4418-8a4e-78c4ea2aaaa5","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":476.187483,"created":"2025-04-09T07:49:07.298389","updated":"2025-04-09T07:49:07.298395","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a296e05c-eb70-4418-8a4e-78c4ea2aaaa5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a296e05c-eb70-4418-8a4e-78c4ea2aaaa5/pipeline.log\">pipeline</a>"]},{"id":"a562d696-6235-4996-b08b-24594cda514a","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":886.342627,"created":"2025-04-09T07:49:07.056453","updated":"2025-04-09T07:49:07.056461","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a562d696-6235-4996-b08b-24594cda514a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a562d696-6235-4996-b08b-24594cda514a/pipeline.log\">pipeline</a>"]},{"id":"fddf3e87-e464-4afe-9bef-71136169d199","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":886.767217,"created":"2025-04-09T07:49:05.358189","updated":"2025-04-09T07:49:05.358198","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fddf3e87-e464-4afe-9bef-71136169d199\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fddf3e87-e464-4afe-9bef-71136169d199/pipeline.log\">pipeline</a>"]},{"id":"2d53243c-2e8d-4fee-b0f1-d7792cba7803","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1098.081644,"created":"2025-04-09T07:49:09.400358","updated":"2025-04-09T07:49:09.400364","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d53243c-2e8d-4fee-b0f1-d7792cba7803\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d53243c-2e8d-4fee-b0f1-d7792cba7803/pipeline.log\">pipeline</a>"]},{"id":"ec504146-9069-4d19-bdc9-ebe70227063a","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1173.524309,"created":"2025-04-09T07:49:05.204103","updated":"2025-04-09T07:49:05.204143","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec504146-9069-4d19-bdc9-ebe70227063a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec504146-9069-4d19-bdc9-ebe70227063a/pipeline.log\">pipeline</a>"]},{"id":"44e7e2ad-6588-4780-a3bb-c3d3fa3134a1","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":11618.30219,"created":"2025-04-11T06:46:25.162813","updated":"2025-04-11T06:46:25.162820","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44e7e2ad-6588-4780-a3bb-c3d3fa3134a1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44e7e2ad-6588-4780-a3bb-c3d3fa3134a1/pipeline.log\">pipeline</a>"]}]} -->