### PR TITLE
[build resilience fix] Begin doing user / group setup ourselves

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -41,9 +41,8 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff-base ${NAME}-server" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff-base" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -37,10 +37,12 @@ LABEL summary="${SUMMARY}" \
 
 EXPOSE 3306
 
-# This image must forever use UID 27 for mysql user so our volumes are
-# safe in the future. This should *never* change, the last test is there
-# to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base" && \
+# This image must forever use UID 27 for mysql user so our volumes are safe in the future. This should *never* change.
+# Instead of relying on the DB server package, we will do the setup ourselves before any package is installed
+RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
+    /usr/sbin/useradd -M -N -g mysql -o -r -d ${HOME} -s /sbin/nologin -c "MySQL Server" -u 27 mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)" && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \


### PR DESCRIPTION
The user / group creation process develops. The UID / GID 27 is no longer guaranteed !! With the comming of sysusers.d user creation to Fedora:
  https://fedoraproject.org/wiki/Changes/RPMSuportForSystemdSysusers
packages are switching to the new technology.

That brings a wind of change into the MariaDB / MySQL packages in Fedora. Justification for the hardcoded UID / GID 27 does not exist for quite some time. MariaDB upstream use dynamic UID / GID assignment via sysusers.d for nearly a decade now.

The drop of the hardcoded UID / GID 27 in Fedora / RHEL packages may happen. We MUST stop relying on the packages to guarantee the hardcoded value at least from Fedora 42.

For that reasons:

- cherry-pick the user / group creation code from the DB package itself https://src.fedoraproject.org/rpms/mariadb10.11/blob/9cc88/f/mariadb10.11.spec#_1377 with the difference that here we want to get all of the potential error output, thus removing '>/dev/null 2>&1 || :' which is otherwise necessary in case of RPM scriptlets, as package installation MUST NOT be blocked by failed scriptlets
- put it before any package is installed
- test the UID / GID is correct both after UID / GID setup and then again after packages installation to be double sure

Expected cases:

CASE:
  We set up UID / GID ourselves, and after that DB server package tries that too during its installation via RPM scriptlet RESULT:
  The RPM scriptlet fails, as the user / group exists already, but package installas normally, resulting in correct UID / GID setup being kept CONTAINER BUILD PASS

CASE:
  We set up UID / GID ourselves, and after that DB server package tries that too during its installation via sysusers.d setup RESULT:
  sysusers.d is intentionally designed in a way that when the user / group exists already,the creation command is silently ignored, resulting in correct UID / GID setup being kept CONTAINER BUILD PASS

CASE:
  The 'mysql' user / group is *somehow* already present in the container base image already RESULT:
  the user / group creation code added by this commit fails, wich is good, as human investigation is required to find out how that possibly happened, and also we wouldn't be able to guarantee the correct UID / GID in that case. CONTAINER BUILD FAIL

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"2787097313"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2787754224","data":[{"id":"3ae4711f-9513-44e1-bf38-d443b6f0d336","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":3994.329248,"created":"2025-04-08T20:52:22.393170","updated":"2025-04-08T20:52:22.393180","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ae4711f-9513-44e1-bf38-d443b6f0d336\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ae4711f-9513-44e1-bf38-d443b6f0d336/pipeline.log\">pipeline</a>"]},{"id":"4e605d6c-ddb0-460c-92cb-732bccc2ba2b","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":4039.961349,"created":"2025-04-08T20:52:52.385702","updated":"2025-04-08T20:52:52.385709","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4e605d6c-ddb0-460c-92cb-732bccc2ba2b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4e605d6c-ddb0-460c-92cb-732bccc2ba2b/pipeline.log\">pipeline</a>"]},{"id":"71699014-0a9d-4a43-85fc-28a4a28c6411","name":"RHEL10 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":6911.469592,"created":"2025-04-08T20:52:19.634939","updated":"2025-04-08T20:52:19.634945","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/71699014-0a9d-4a43-85fc-28a4a28c6411\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/71699014-0a9d-4a43-85fc-28a4a28c6411/pipeline.log\">pipeline</a>"]},{"id":"d1bb90fd-9147-4352-b02d-1469947a9cfc","name":"RHEL8 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":7252.134337,"created":"2025-04-08T20:52:23.380883","updated":"2025-04-08T20:52:23.380889","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1bb90fd-9147-4352-b02d-1469947a9cfc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1bb90fd-9147-4352-b02d-1469947a9cfc/pipeline.log\">pipeline</a>"]},{"id":"4d4b7ce8-6ba4-415e-a8fe-525da21951d4","name":"RHEL9 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"error","runTime":7510.615224,"created":"2025-04-08T20:52:30.548224","updated":"2025-04-08T20:52:30.548232","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4d4b7ce8-6ba4-415e-a8fe-525da21951d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4d4b7ce8-6ba4-415e-a8fe-525da21951d4/pipeline.log\">pipeline</a>"]},{"id":"0e0c9cbe-b6f0-4769-b3e8-6f671e4a5e20","name":"RHEL8 - PyTest - OpenShift 4 - 10.3","status":"complete","outcome":"error","runTime":7803.828088,"created":"2025-04-08T20:52:27.360066","updated":"2025-04-08T20:52:27.360071","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e0c9cbe-b6f0-4769-b3e8-6f671e4a5e20\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e0c9cbe-b6f0-4769-b3e8-6f671e4a5e20/pipeline.log\">pipeline</a>"]},{"id":"3bebce7f-8f64-4d80-b959-186649ee4d9c","name":"RHEL9 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"error","runTime":7834.241809,"created":"2025-04-08T20:52:25.436663","updated":"2025-04-08T20:52:25.436670","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3bebce7f-8f64-4d80-b959-186649ee4d9c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3bebce7f-8f64-4d80-b959-186649ee4d9c/pipeline.log\">pipeline</a>"]},{"id":"91a836f9-97ff-4fa6-92c9-261f6714b07c","name":"RHEL8 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"error","runTime":7870.644899,"created":"2025-04-08T20:52:21.472541","updated":"2025-04-08T20:52:21.472546","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/91a836f9-97ff-4fa6-92c9-261f6714b07c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/91a836f9-97ff-4fa6-92c9-261f6714b07c/pipeline.log\">pipeline</a>"]},{"id":"fdcfe5fd-2d02-477c-9c98-02b9b8464f01","name":"RHEL10 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":3979.554321,"created":"2025-04-08T22:01:58.187547","updated":"2025-04-08T22:01:58.187554","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdcfe5fd-2d02-477c-9c98-02b9b8464f01\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdcfe5fd-2d02-477c-9c98-02b9b8464f01/pipeline.log\">pipeline</a>"]},{"id":"391dbc29-5f06-47b0-a265-485f902f11ec","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":4583.65261,"created":"2025-04-08T21:52:01.326950","updated":"2025-04-08T21:52:01.326956","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/391dbc29-5f06-47b0-a265-485f902f11ec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/391dbc29-5f06-47b0-a265-485f902f11ec/pipeline.log\">pipeline</a>"]},{"id":"98180adc-1f9c-4b24-8a3d-9c3fbb2a6472","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":4395.570444,"created":"2025-04-08T22:00:02.479781","updated":"2025-04-08T22:00:02.479788","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/98180adc-1f9c-4b24-8a3d-9c3fbb2a6472\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/98180adc-1f9c-4b24-8a3d-9c3fbb2a6472/pipeline.log\">pipeline</a>"]},{"id":"3354904c-7c82-4475-bd3f-41ad35c1e2c6","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":4848.051584,"created":"2025-04-08T22:48:40.734991","updated":"2025-04-08T22:48:40.734997","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3354904c-7c82-4475-bd3f-41ad35c1e2c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3354904c-7c82-4475-bd3f-41ad35c1e2c6/pipeline.log\">pipeline</a>"]},{"id":"29ded0a3-7b6d-4709-b8ad-b2adccc52e68","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":498.065464,"created":"2025-04-23T13:05:28.382187","updated":"2025-04-23T13:05:28.382196","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/29ded0a3-7b6d-4709-b8ad-b2adccc52e68\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/29ded0a3-7b6d-4709-b8ad-b2adccc52e68/pipeline.log\">pipeline</a>"]},{"id":"793c34fd-a9cf-47f5-8a51-e39582f52e44","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":501.472502,"created":"2025-04-23T13:05:30.262130","updated":"2025-04-23T13:05:30.262139","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/793c34fd-a9cf-47f5-8a51-e39582f52e44\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/793c34fd-a9cf-47f5-8a51-e39582f52e44/pipeline.log\">pipeline</a>"]},{"id":"9cf5a379-e345-46c4-a4e0-2b2944bb0028","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":493.591549,"created":"2025-04-23T13:05:29.272712","updated":"2025-04-23T13:05:29.272717","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9cf5a379-e345-46c4-a4e0-2b2944bb0028\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9cf5a379-e345-46c4-a4e0-2b2944bb0028/pipeline.log\">pipeline</a>"]},{"id":"4ce8605e-ef13-422d-8e11-9711d25a10c7","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":617.70262,"created":"2025-04-23T13:05:29.216697","updated":"2025-04-23T13:05:29.216704","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4ce8605e-ef13-422d-8e11-9711d25a10c7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4ce8605e-ef13-422d-8e11-9711d25a10c7/pipeline.log\">pipeline</a>"]},{"id":"d550f703-a3d8-4f5e-9482-d5aed06dcc67","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":4867.298381,"created":"2025-04-23T13:05:50.558616","updated":"2025-04-23T13:05:50.558624","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d550f703-a3d8-4f5e-9482-d5aed06dcc67\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d550f703-a3d8-4f5e-9482-d5aed06dcc67/pipeline.log\">pipeline</a>"]},{"id":"6be0e69b-4a30-45d0-a8f9-9abb462c186a","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":5128.623335,"created":"2025-04-23T13:05:27.190992","updated":"2025-04-23T13:05:27.190998","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6be0e69b-4a30-45d0-a8f9-9abb462c186a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6be0e69b-4a30-45d0-a8f9-9abb462c186a/pipeline.log\">pipeline</a>"]},{"id":"20c4a791-9200-41c9-934c-79b76d5cbdcf","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":4615.094477,"created":"2025-04-23T13:05:27.233522","updated":"2025-04-23T13:05:27.233528","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/20c4a791-9200-41c9-934c-79b76d5cbdcf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/20c4a791-9200-41c9-934c-79b76d5cbdcf/pipeline.log\">pipeline</a>"]},{"id":"bf2baf98-0296-4691-bec7-93e540a5b3a9","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":5062.757648,"created":"2025-04-23T13:05:29.402723","updated":"2025-04-23T13:05:29.402729","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf2baf98-0296-4691-bec7-93e540a5b3a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf2baf98-0296-4691-bec7-93e540a5b3a9/pipeline.log\">pipeline</a>"]},{"id":"5939f87f-9311-4fbe-a20d-d5f398d04d7b","name":"RHEL8 - 10.3","runTime":5640.563187,"created":"2025-04-23T13:05:30.134347","updated":"2025-04-23T13:05:30.134355","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5939f87f-9311-4fbe-a20d-d5f398d04d7b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5939f87f-9311-4fbe-a20d-d5f398d04d7b/pipeline.log\">pipeline</a>"]},{"id":"b81a317d-2645-45a4-ba4d-db11ce8674ed","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":5616.737876,"created":"2025-04-23T13:05:30.172711","updated":"2025-04-23T13:05:30.172717","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b81a317d-2645-45a4-ba4d-db11ce8674ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b81a317d-2645-45a4-ba4d-db11ce8674ed/pipeline.log\">pipeline</a>"]}]} -->