### PR TITLE
[build resilience fix] Install DB packages via versioned names

### DIFF
--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -40,9 +40,8 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base ${NAME}-server" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
+RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname bind-utils groff-base" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -41,9 +41,8 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff-base ${NAME}-server" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname bind-utils groff-base" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \


### PR DESCRIPTION
MariaDB and MySQL package switched to the versioned package layout in Fedora and RHEL 10. The packages can be available in various states, but in all case where a specific version is wanted, specific version must be requested.

Thus container wanting MariaDB 10.11 specifically, must request to install 'mariadb10.11-server' specifically, instead of just 'mariadb-server' which will give you any version that is selected to be the distribution default the current moment.

<!-- issue-commentator = {"comment-id":"2787097841"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2787895540","data":[{"id":"7a6648cd-44c3-4448-b721-4e5a9478a664","name":"RHEL10 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":6761.798416,"created":"2025-04-08T22:01:53.165056","updated":"2025-04-08T22:01:53.165062","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a6648cd-44c3-4448-b721-4e5a9478a664\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a6648cd-44c3-4448-b721-4e5a9478a664/pipeline.log\">pipeline</a>"]},{"id":"6ee0afb1-844d-4f2f-96b1-e9405350085f","name":"RHEL9 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":7503.241311,"created":"2025-04-08T22:03:00.709184","updated":"2025-04-08T22:03:00.709190","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ee0afb1-844d-4f2f-96b1-e9405350085f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ee0afb1-844d-4f2f-96b1-e9405350085f/pipeline.log\">pipeline</a>"]},{"id":"f06c5a75-0587-48f2-972a-16f1d63b632e","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":4839.460394,"created":"2025-04-08T22:48:50.369681","updated":"2025-04-08T22:48:50.369686","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f06c5a75-0587-48f2-972a-16f1d63b632e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f06c5a75-0587-48f2-972a-16f1d63b632e/pipeline.log\">pipeline</a>"]},{"id":"76b53fbb-be0e-4848-81bb-3dc7d8dbc627","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":5046.599241,"created":"2025-04-08T22:50:18.346162","updated":"2025-04-08T22:50:18.346175","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/76b53fbb-be0e-4848-81bb-3dc7d8dbc627\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/76b53fbb-be0e-4848-81bb-3dc7d8dbc627/pipeline.log\">pipeline</a>"]},{"id":"7679256e-6d12-4768-a749-6a774b7db521","name":"RHEL10 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":4825.035841,"created":"2025-04-08T22:55:18.588966","updated":"2025-04-08T22:55:18.588975","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7679256e-6d12-4768-a749-6a774b7db521\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7679256e-6d12-4768-a749-6a774b7db521/pipeline.log\">pipeline</a>"]},{"id":"d1434388-11bb-45ee-9ad8-4dc22b3bed08","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":5026.029035,"created":"2025-04-08T22:53:03.911679","updated":"2025-04-08T22:53:03.911686","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1434388-11bb-45ee-9ad8-4dc22b3bed08\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1434388-11bb-45ee-9ad8-4dc22b3bed08/pipeline.log\">pipeline</a>"]},{"id":"5849ce4b-ada6-4e87-a182-95a71e011c77","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":4988.708879,"created":"2025-04-08T22:54:49.179750","updated":"2025-04-08T22:54:49.179756","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5849ce4b-ada6-4e87-a182-95a71e011c77\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5849ce4b-ada6-4e87-a182-95a71e011c77/pipeline.log\">pipeline</a>"]},{"id":"181f448b-5b10-4d72-8070-b31511d507e1","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":5174.801512,"created":"2025-04-08T22:56:03.988012","updated":"2025-04-08T22:56:03.988017","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/181f448b-5b10-4d72-8070-b31511d507e1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/181f448b-5b10-4d72-8070-b31511d507e1/pipeline.log\">pipeline</a>"]},{"id":"93f91ee7-e010-4f71-b63f-d72a3daf22bc","name":"RHEL8 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":8839.586203,"created":"2025-04-08T21:58:44.574294","updated":"2025-04-08T21:58:44.574300","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/93f91ee7-e010-4f71-b63f-d72a3daf22bc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/93f91ee7-e010-4f71-b63f-d72a3daf22bc/pipeline.log\">pipeline</a>"]},{"id":"3538817d-f1ef-4e54-825c-ca0b9bc480e8","name":"RHEL8 - PyTest - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":9130.570757,"created":"2025-04-08T22:06:07.486269","updated":"2025-04-08T22:06:07.486275","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3538817d-f1ef-4e54-825c-ca0b9bc480e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3538817d-f1ef-4e54-825c-ca0b9bc480e8/pipeline.log\">pipeline</a>"]},{"id":"44ab694c-3ec1-4b63-8d5a-4668193a0aa2","name":"RHEL9 - PyTest - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":7648.708873,"created":"2025-04-08T22:46:10.776677","updated":"2025-04-08T22:46:10.776685","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44ab694c-3ec1-4b63-8d5a-4668193a0aa2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44ab694c-3ec1-4b63-8d5a-4668193a0aa2/pipeline.log\">pipeline</a>"]},{"id":"87974991-e5ec-48b5-87cb-6f92d013d44a","name":"RHEL8 - PyTest - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":11458.229098,"created":"2025-04-08T21:58:47.454827","updated":"2025-04-08T21:58:47.454832","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87974991-e5ec-48b5-87cb-6f92d013d44a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87974991-e5ec-48b5-87cb-6f92d013d44a/pipeline.log\">pipeline</a>"]},{"id":"d001f83f-fe8b-4973-9dd8-57830ea785db","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":446.514546,"created":"2025-04-11T17:47:30.396286","updated":"2025-04-11T17:47:30.396292","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d001f83f-fe8b-4973-9dd8-57830ea785db\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d001f83f-fe8b-4973-9dd8-57830ea785db/pipeline.log\">pipeline</a>"]},{"id":"4821931f-84a6-474a-b029-8a522cbae996","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":450.166634,"created":"2025-04-11T17:47:31.787530","updated":"2025-04-11T17:47:31.787535","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4821931f-84a6-474a-b029-8a522cbae996\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4821931f-84a6-474a-b029-8a522cbae996/pipeline.log\">pipeline</a>"]},{"id":"55db67db-a673-47d5-a4ef-29978018626a","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":492.301014,"created":"2025-04-11T17:47:32.290856","updated":"2025-04-11T17:47:32.290864","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/55db67db-a673-47d5-a4ef-29978018626a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/55db67db-a673-47d5-a4ef-29978018626a/pipeline.log\">pipeline</a>"]},{"id":"aa277a89-b23c-4183-8a7e-caf0130055c1","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":614.901115,"created":"2025-04-11T17:47:29.823821","updated":"2025-04-11T17:47:29.823830","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/aa277a89-b23c-4183-8a7e-caf0130055c1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/aa277a89-b23c-4183-8a7e-caf0130055c1/pipeline.log\">pipeline</a>"]},{"id":"5e0a2dba-5e2d-4297-91ac-4dbd725722ec","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1111.695156,"created":"2025-04-11T17:47:30.421986","updated":"2025-04-11T17:47:30.421995","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e0a2dba-5e2d-4297-91ac-4dbd725722ec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e0a2dba-5e2d-4297-91ac-4dbd725722ec/pipeline.log\">pipeline</a>"]},{"id":"921905cc-825f-4572-a9ce-20f7fc07daa9","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1399.405949,"created":"2025-04-11T17:47:29.686691","updated":"2025-04-11T17:47:29.686696","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/921905cc-825f-4572-a9ce-20f7fc07daa9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/921905cc-825f-4572-a9ce-20f7fc07daa9/pipeline.log\">pipeline</a>"]},{"id":"8c74d8ca-7f31-454f-96e6-65294034ca24","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1109.573242,"created":"2025-04-11T17:47:32.728818","updated":"2025-04-11T17:47:32.728824","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c74d8ca-7f31-454f-96e6-65294034ca24\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c74d8ca-7f31-454f-96e6-65294034ca24/pipeline.log\">pipeline</a>"]},{"id":"34417485-e263-452e-9357-426f556346ee","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1549.873655,"created":"2025-04-11T17:47:31.282151","updated":"2025-04-11T17:47:31.282158","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/34417485-e263-452e-9357-426f556346ee\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/34417485-e263-452e-9357-426f556346ee/pipeline.log\">pipeline</a>"]},{"id":"5ac2767a-fa60-427d-8aa4-a040d2c891f9","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":1068.90698,"created":"2025-04-11T17:47:30.038245","updated":"2025-04-11T17:47:30.038251","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ac2767a-fa60-427d-8aa4-a040d2c891f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ac2767a-fa60-427d-8aa4-a040d2c891f9/pipeline.log\">pipeline</a>"]},{"id":"b53937e2-99bb-4765-95dc-96724a8b0152","name":"RHEL8 - 10.11","runTime":1845.562992,"created":"2025-04-11T17:47:30.213792","updated":"2025-04-11T17:47:30.213800","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b53937e2-99bb-4765-95dc-96724a8b0152\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b53937e2-99bb-4765-95dc-96724a8b0152/pipeline.log\">pipeline</a>"]}]} -->