### PR TITLE
Fix environment variables

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -10,8 +10,10 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.11
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -11,7 +11,7 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -11,7 +11,7 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -10,8 +10,10 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.11
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -11,7 +11,7 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -10,8 +10,10 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.11
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -10,8 +10,10 @@ FROM ubi10/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.11
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -11,7 +11,7 @@ FROM ubi10/s2i-core
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -10,8 +10,10 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.11
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -11,7 +11,7 @@ FROM ubi9/s2i-core
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -10,8 +10,10 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.5
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -11,7 +11,7 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=105 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -10,8 +10,10 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
+# Standalone ENV call so this value can be re-used in the other ENVs
+ENV MYSQL_VERSION=10.5
+
+ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -11,7 +11,7 @@ FROM ubi9/s2i-core
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=105 \
+    MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
     VERSION=${MYSQL_VERSION} \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \


### PR DESCRIPTION
[bugfix] The version must be set in a separate stage, so it can be re-used in the other calls otherwise it's not available when the rest of the ENV block is processed and the ENV values relying on this variable are malformed.

diff of the podman inspect - before the fix and after:
```
               "Env": [                                                        "Env": [
...
                    "MYSQL_VERSION=10.11",                                          "MYSQL_VERSION=10.11",
                    "MYSQL_SHORT_VERSION=1011",                                     "MYSQL_SHORT_VERSION=1011",
                    "VERSION=",                               |                     "VERSION=10.11",
                    "APP_DATA=/opt/app-root/src",                                   "APP_DATA=/opt/app-root/src",
                    "HOME=/var/lib/mysql",                                          "HOME=/var/lib/mysql",
                    "NAME=mariadb",                                                 "NAME=mariadb",
                    "ARCH=x86_64",                                                  "ARCH=x86_64",
                    "SUMMARY=MariaDB  SQL database server",   |                     "SUMMARY=MariaDB 10.11 SQL database serve
...


               "Labels": {                                                     "Labels": {
...
                    "summary": "MariaDB  SQL database server" |                     "summary": "MariaDB 10.11 SQL database se


```
Notice the repeated missing "10.11" in the left column.

<!-- issue-commentator = {"comment-id":"2876382033"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2876408279","data":[{"id":"fea7547b-1d14-42c0-a980-b2ccb683b01e","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":484.017558,"created":"2025-05-13T12:49:38.968309","updated":"2025-05-13T12:49:38.968317","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fea7547b-1d14-42c0-a980-b2ccb683b01e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fea7547b-1d14-42c0-a980-b2ccb683b01e/pipeline.log\">pipeline</a>"]},{"id":"f6dbb374-6c0a-45a9-a0d9-61d7a7846fc8","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":566.907141,"created":"2025-05-13T12:49:35.982136","updated":"2025-05-13T12:49:35.982146","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6dbb374-6c0a-45a9-a0d9-61d7a7846fc8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6dbb374-6c0a-45a9-a0d9-61d7a7846fc8/pipeline.log\">pipeline</a>"]},{"id":"f4e2823f-9d96-4d46-99c7-c1ffe4459d27","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":563.58106,"created":"2025-05-13T12:49:39.496524","updated":"2025-05-13T12:49:39.496532","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f4e2823f-9d96-4d46-99c7-c1ffe4459d27\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f4e2823f-9d96-4d46-99c7-c1ffe4459d27/pipeline.log\">pipeline</a>"]},{"id":"260a713e-0e55-48c7-90d0-065e27ffd0a0","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":575.059831,"created":"2025-05-13T12:49:36.436430","updated":"2025-05-13T12:49:36.436436","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/260a713e-0e55-48c7-90d0-065e27ffd0a0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/260a713e-0e55-48c7-90d0-065e27ffd0a0/pipeline.log\">pipeline</a>"]},{"id":"44737dbc-ab18-4672-bf88-b3f2b436cff6","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":650.224363,"created":"2025-05-13T12:49:37.749631","updated":"2025-05-13T12:49:37.749647","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/44737dbc-ab18-4672-bf88-b3f2b436cff6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/44737dbc-ab18-4672-bf88-b3f2b436cff6/pipeline.log\">pipeline</a>"]},{"id":"d554f840-8142-4fb4-8cd7-1a3fe9d7a0cc","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":1001.122986,"created":"2025-05-13T12:49:36.183916","updated":"2025-05-13T12:49:36.183922","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d554f840-8142-4fb4-8cd7-1a3fe9d7a0cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d554f840-8142-4fb4-8cd7-1a3fe9d7a0cc/pipeline.log\">pipeline</a>"]},{"id":"50b7cc1c-47da-44f0-898c-dba496aeccb3","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1129.683685,"created":"2025-05-13T12:49:34.796269","updated":"2025-05-13T12:49:34.796277","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/50b7cc1c-47da-44f0-898c-dba496aeccb3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/50b7cc1c-47da-44f0-898c-dba496aeccb3/pipeline.log\">pipeline</a>"]},{"id":"1d013f78-f334-4846-be4d-2d21860c5d5d","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1173.334903,"created":"2025-05-13T12:49:37.320189","updated":"2025-05-13T12:49:37.320196","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d013f78-f334-4846-be4d-2d21860c5d5d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d013f78-f334-4846-be4d-2d21860c5d5d/pipeline.log\">pipeline</a>"]},{"id":"03f5479d-bf9c-4485-8564-fbacc5d85678","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1152.314973,"created":"2025-05-13T12:49:39.393097","updated":"2025-05-13T12:49:39.393105","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/03f5479d-bf9c-4485-8564-fbacc5d85678\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/03f5479d-bf9c-4485-8564-fbacc5d85678/pipeline.log\">pipeline</a>"]},{"id":"325dae0c-edd4-4e50-825e-ccb230cf72d6","name":"RHEL9 - 10.5","runTime":1160.918125,"created":"2025-05-13T12:49:37.825414","updated":"2025-05-13T12:49:37.825421","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/325dae0c-edd4-4e50-825e-ccb230cf72d6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/325dae0c-edd4-4e50-825e-ccb230cf72d6/pipeline.log\">pipeline</a>"]}]} -->