### PR TITLE
[buildah fix attempt] Try to fix the "Missing : in substitution: ${MY…

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -13,8 +13,8 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.11
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -13,8 +13,8 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.11
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -13,8 +13,8 @@ FROM quay.io/fedora/s2i-core:42
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.11
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -13,8 +13,8 @@ FROM ubi10/s2i-core
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.11
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -13,8 +13,8 @@ FROM ubi9/s2i-core
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.11
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -13,8 +13,8 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.5
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -13,8 +13,8 @@ FROM ubi9/s2i-core
 # Standalone ENV call so this value can be re-used in the other ENVs
 ENV MYSQL_VERSION=10.5
 
-ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./} \
-    VERSION=${MYSQL_VERSION} \
+ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+    VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \


### PR DESCRIPTION
…SQL_VERSION//./}" error

appearing only in 'buildah' tool

 | build-and-push (8.0/Dockerfile.fedora, 8.0, fedora, 80, QUAY_IMAGE_FEDORA_BUILDER_USERNAME, QUAY_...
 | Error: buildah exited with code 125
 | Trying to pull quay.io/fedora/s2i-core:42...
 | Getting image source signatures
 | Copying blob sha256:4d0e9393bf7fe7621a579be8b8820997a3b276323479dd344e5214dd7567cf1e
 | Copying blob sha256:47d4fc1eea7242147b689ace18a3395e804126733e6c35a7ce9f20ee2b455727
 | Copying config sha256:47af983050a0c2b96a7a0bdddee75d6a7415b8fb754a913cae98dea45296da20
 | Writing manifest to image destination
 | Error: resolving step {Value:env Next:0xc0001547e0 Children:[] Attributes:map[] Original:ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./}     APP_DATA=/opt/app-root/src     HOME=/var/lib/mysql     NAME=mysql Flags:[] StartLine:16 EndLine:19}: Missing ':' in substitution: ${MYSQL_VERSION//./}

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"2886270323"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2886286694","data":[{"id":"4d4d1fd2-ce15-4954-b5db-7cdc78a07b01","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":379.937577,"created":"2025-05-16T10:04:45.653678","updated":"2025-05-16T10:04:45.653683","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4d4d1fd2-ce15-4954-b5db-7cdc78a07b01\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4d4d1fd2-ce15-4954-b5db-7cdc78a07b01/pipeline.log\">pipeline</a>"]},{"id":"d29cbec8-1622-4813-ab3f-b3484c06de7f","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":484.87512,"created":"2025-05-16T10:04:43.360322","updated":"2025-05-16T10:04:43.360327","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d29cbec8-1622-4813-ab3f-b3484c06de7f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d29cbec8-1622-4813-ab3f-b3484c06de7f/pipeline.log\">pipeline</a>"]},{"id":"575b771a-ae5f-459b-b358-564a64143e7f","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":493.799975,"created":"2025-05-16T10:04:47.028636","updated":"2025-05-16T10:04:47.028642","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/575b771a-ae5f-459b-b358-564a64143e7f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/575b771a-ae5f-459b-b358-564a64143e7f/pipeline.log\">pipeline</a>"]},{"id":"47813d2f-916b-475b-bd17-23650741189a","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":550.866112,"created":"2025-05-16T10:04:45.056235","updated":"2025-05-16T10:04:45.056242","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/47813d2f-916b-475b-bd17-23650741189a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/47813d2f-916b-475b-bd17-23650741189a/pipeline.log\">pipeline</a>"]},{"id":"b7b79b8e-83aa-4cc7-807c-1207fde745c6","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":566.859954,"created":"2025-05-16T10:04:45.080132","updated":"2025-05-16T10:04:45.080141","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b7b79b8e-83aa-4cc7-807c-1207fde745c6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b7b79b8e-83aa-4cc7-807c-1207fde745c6/pipeline.log\">pipeline</a>"]},{"id":"a4fa6479-ea93-4c0d-af76-29a81b53e4d5","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":955.051001,"created":"2025-05-16T10:04:47.028734","updated":"2025-05-16T10:04:47.028740","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4fa6479-ea93-4c0d-af76-29a81b53e4d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4fa6479-ea93-4c0d-af76-29a81b53e4d5/pipeline.log\">pipeline</a>"]},{"id":"029b1c7e-61ae-415d-873a-7129a4ece489","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1171.396805,"created":"2025-05-16T10:04:46.009886","updated":"2025-05-16T10:04:46.009892","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/029b1c7e-61ae-415d-873a-7129a4ece489\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/029b1c7e-61ae-415d-873a-7129a4ece489/pipeline.log\">pipeline</a>"]},{"id":"3cad160f-72b5-4095-85b5-37fe6399d522","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1192.982528,"created":"2025-05-16T10:04:46.237938","updated":"2025-05-16T10:04:46.237945","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cad160f-72b5-4095-85b5-37fe6399d522\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cad160f-72b5-4095-85b5-37fe6399d522/pipeline.log\">pipeline</a>"]},{"id":"519cb086-5b60-4a35-a5cd-b7b3ddd7432e","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1212.503213,"created":"2025-05-16T10:04:44.648661","updated":"2025-05-16T10:04:44.648668","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/519cb086-5b60-4a35-a5cd-b7b3ddd7432e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/519cb086-5b60-4a35-a5cd-b7b3ddd7432e/pipeline.log\">pipeline</a>"]},{"id":"18a4bc76-7b1c-4c90-82ec-6627a9f37bcd","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1248.066808,"created":"2025-05-16T10:04:46.028624","updated":"2025-05-16T10:04:46.028629","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/18a4bc76-7b1c-4c90-82ec-6627a9f37bcd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/18a4bc76-7b1c-4c90-82ec-6627a9f37bcd/pipeline.log\">pipeline</a>"]},{"id":"7daf30fb-8b51-4523-b1a2-5dd95279502d","name":"RHEL9 - 10.11","runTime":1292.262707,"created":"2025-05-16T10:04:46.138033","updated":"2025-05-16T10:04:46.138039","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7daf30fb-8b51-4523-b1a2-5dd95279502d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7daf30fb-8b51-4523-b1a2-5dd95279502d/pipeline.log\">pipeline</a>"]}]} -->