### PR TITLE
[revert] Revert using bash parameter substitution, 'bash' is not guaranteed

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -10,10 +10,8 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.11
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.11 \
+    MYSQL_SHORT_VERSION=1011 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -10,10 +10,8 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.11
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.11 \
+    MYSQL_SHORT_VERSION=1011 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -10,10 +10,8 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.11
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.11 \
+    MYSQL_SHORT_VERSION=1011 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -10,10 +10,8 @@ FROM ubi10/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.11
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.11 \
+    MYSQL_SHORT_VERSION=1011 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -10,10 +10,8 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.11
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.11 \
+    MYSQL_SHORT_VERSION=1011 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -10,10 +10,8 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.5
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.5 \
+    MYSQL_SHORT_VERSION=105 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -10,10 +10,8 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-# Standalone ENV call so this value can be re-used in the other ENVs
-ENV MYSQL_VERSION=10.5
-
-ENV MYSQL_SHORT_VERSION="${MYSQL_VERSION//./}" \
+ENV MYSQL_VERSION=10.5 \
+    MYSQL_SHORT_VERSION=105 \
     VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \


### PR DESCRIPTION
Build system without bash fails with:
 | Error: resolving step {Value:env Next:0xc0001524d0 Children:[]
 | Attributes:map[] Original:ENV MYSQL_SHORT_VERSION=${MYSQL_VERSION//./}
 | VERSION=${MYSQL_VERSION}     APP_DATA=/opt/app-root/src     HOME=/var/lib/mysql
 | NAME=mariadb     SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server"
 | DESCRIPTION="..."
 | Flags:[] StartLine:16 EndLine:25}: Missing ':' in substitution: ${MYSQL_VERSION//./}

I tried a lot of ways to work around this, none worked.

Using subshells
 - ENV does not support white characters on the right side of assignment Using subshells with scrambled whitepsace characters
 - ENV won't invoke the subshell, will treat right side of the assignement as a simple text Using RUN to set $SHELL, trying to use 'export'
 - won't be preserved between layers using SHELL directive
 - Docker specific

Fedora only knows '/bin/bash' and 'sh' is just a symbolic link to '/bin/bash'. So the 'sh' unable to do the parameter expansions must come from the build host.

My guess would be that setting 'shell: bash' here:
  https://github.com/sclorg/build-and-push-action/blob/main/action.yml#L115
might help.

However this seems to be impossible to force inside of the containerfile itself, so I'm reverting the bash parameter substitution code entirely.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"2886577986"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2886594767","data":[{"id":"9080e495-fa70-467c-a1f3-f53fd6199c6d","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":434.033765,"created":"2025-05-16T12:25:28.048597","updated":"2025-05-16T12:25:28.048603","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9080e495-fa70-467c-a1f3-f53fd6199c6d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9080e495-fa70-467c-a1f3-f53fd6199c6d/pipeline.log\">pipeline</a>"]},{"id":"467ea1ec-61c3-44df-b190-a8d8face705b","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":491.660534,"created":"2025-05-16T12:25:26.158856","updated":"2025-05-16T12:25:26.158865","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/467ea1ec-61c3-44df-b190-a8d8face705b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/467ea1ec-61c3-44df-b190-a8d8face705b/pipeline.log\">pipeline</a>"]},{"id":"7ba41642-1729-4aad-9508-a55fe95eae8b","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":488.56889,"created":"2025-05-16T12:25:28.010100","updated":"2025-05-16T12:25:28.010133","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7ba41642-1729-4aad-9508-a55fe95eae8b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7ba41642-1729-4aad-9508-a55fe95eae8b/pipeline.log\">pipeline</a>"]},{"id":"2c7d86f2-d887-486f-80b7-8edd3d8c6916","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":559.162363,"created":"2025-05-16T12:25:27.601822","updated":"2025-05-16T12:25:27.601828","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2c7d86f2-d887-486f-80b7-8edd3d8c6916\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2c7d86f2-d887-486f-80b7-8edd3d8c6916/pipeline.log\">pipeline</a>"]},{"id":"1cb1f8a2-2c0a-4719-984b-eb62141934e9","name":"Fedora - 10.5","status":"complete","outcome":"passed","runTime":558.708044,"created":"2025-05-16T12:25:26.965577","updated":"2025-05-16T12:25:26.965582","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1cb1f8a2-2c0a-4719-984b-eb62141934e9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1cb1f8a2-2c0a-4719-984b-eb62141934e9/pipeline.log\">pipeline</a>"]},{"id":"770aba7c-747a-4010-b3d2-c8a9fc4cc1a5","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":1005.440305,"created":"2025-05-16T12:25:24.931685","updated":"2025-05-16T12:25:24.931693","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/770aba7c-747a-4010-b3d2-c8a9fc4cc1a5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/770aba7c-747a-4010-b3d2-c8a9fc4cc1a5/pipeline.log\">pipeline</a>"]},{"id":"5f394b16-a4ea-42a1-b1dc-fef6fe46e28f","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1153.884243,"created":"2025-05-16T12:25:27.429009","updated":"2025-05-16T12:25:27.429015","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f394b16-a4ea-42a1-b1dc-fef6fe46e28f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f394b16-a4ea-42a1-b1dc-fef6fe46e28f/pipeline.log\">pipeline</a>"]},{"id":"e14be19c-be69-4246-912e-1b9958e6d11b","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1173.931343,"created":"2025-05-16T12:25:44.930370","updated":"2025-05-16T12:25:44.930377","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e14be19c-be69-4246-912e-1b9958e6d11b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e14be19c-be69-4246-912e-1b9958e6d11b/pipeline.log\">pipeline</a>"]},{"id":"8ad59a1a-2e6f-464a-a08d-7bddb545ed45","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1202.70399,"created":"2025-05-16T12:25:28.163088","updated":"2025-05-16T12:25:28.163096","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ad59a1a-2e6f-464a-a08d-7bddb545ed45\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ad59a1a-2e6f-464a-a08d-7bddb545ed45/pipeline.log\">pipeline</a>"]},{"id":"71dbc1f7-1377-46c2-9bd2-5a13ccd56610","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1183.578502,"created":"2025-05-16T12:25:29.601601","updated":"2025-05-16T12:25:29.601608","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/71dbc1f7-1377-46c2-9bd2-5a13ccd56610\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/71dbc1f7-1377-46c2-9bd2-5a13ccd56610/pipeline.log\">pipeline</a>"]},{"id":"0921b31a-13a8-4ced-befd-0b46feac8619","name":"RHEL9 - 10.11","runTime":1206.77573,"created":"2025-05-16T12:25:28.163593","updated":"2025-05-16T12:25:28.163600","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0921b31a-13a8-4ced-befd-0b46feac8619\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0921b31a-13a8-4ced-befd-0b46feac8619/pipeline.log\">pipeline</a>"]}]} -->