### PR TITLE
[bugfix] The version must be set in a separate stage, so it can be reused in the other calls

### DIFF
--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -10,9 +10,11 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=1011
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -10,9 +10,11 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=1011  
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -10,9 +10,11 @@ FROM quay.io/fedora/s2i-core:42
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=1011  
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -10,13 +10,14 @@ FROM ubi10/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=1011  
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    VERSION=${MYSQL_VERSION} \
     SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -10,9 +10,11 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=1011  
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -10,9 +10,11 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=105 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=105  
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -10,9 +10,11 @@ FROM ubi9/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=105 \
-    VERSION="${MYSQL_VERSION}" \
+    MYSQL_SHORT_VERSION=105 
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \


### PR DESCRIPTION
otherwise it's not available when the rest of the ENV block is processed and the ENV values relying on this variable are malformed.

This commit was mistakenly reverted as a part of revert of a different change

<!-- issue-commentator = {"comment-id":"2901058502"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2901069798","data":[{"id":"a9225cfe-e73b-457c-97f6-47c940554ae3","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":676.70985,"created":"2025-05-23T07:14:28.258454","updated":"2025-05-23T07:14:28.258466","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a9225cfe-e73b-457c-97f6-47c940554ae3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a9225cfe-e73b-457c-97f6-47c940554ae3/pipeline.log\">pipeline</a>"]},{"id":"17a814aa-9c28-4f24-b060-fe0519f5b603","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":435.117312,"created":"2025-05-23T07:14:29.993557","updated":"2025-05-23T07:14:29.993565","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/17a814aa-9c28-4f24-b060-fe0519f5b603\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/17a814aa-9c28-4f24-b060-fe0519f5b603/pipeline.log\">pipeline</a>"]},{"id":"d3308985-71cd-4c42-9794-2a93563a0d74","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":438.052205,"created":"2025-05-23T07:14:28.309398","updated":"2025-05-23T07:14:28.309417","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d3308985-71cd-4c42-9794-2a93563a0d74\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d3308985-71cd-4c42-9794-2a93563a0d74/pipeline.log\">pipeline</a>"]},{"id":"85af51b9-91b0-4c80-a016-abb71dab8ff6","name":"RHEL8 - 10.11","runTime":1070.089445,"created":"2025-05-23T07:14:30.336332","updated":"2025-05-23T07:14:30.336338","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/85af51b9-91b0-4c80-a016-abb71dab8ff6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/85af51b9-91b0-4c80-a016-abb71dab8ff6/pipeline.log\">pipeline</a>"]},{"id":"b6d4f39c-2124-4320-89fa-30cd2128a614","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":991.166861,"created":"2025-05-23T07:14:31.314870","updated":"2025-05-23T07:14:31.314878","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6d4f39c-2124-4320-89fa-30cd2128a614\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6d4f39c-2124-4320-89fa-30cd2128a614/pipeline.log\">pipeline</a>"]},{"id":"039f6f34-5e51-4315-95d3-e07024ddfa04","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":905.974242,"created":"2025-05-23T07:14:37.110756","updated":"2025-05-23T07:14:37.110763","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/039f6f34-5e51-4315-95d3-e07024ddfa04\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/039f6f34-5e51-4315-95d3-e07024ddfa04/pipeline.log\">pipeline</a>"]},{"id":"3bb08d1b-5133-4e79-bde9-d1f602fc73b7","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":491.000942,"created":"2025-05-23T07:14:31.303163","updated":"2025-05-23T07:14:31.303170","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3bb08d1b-5133-4e79-bde9-d1f602fc73b7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3bb08d1b-5133-4e79-bde9-d1f602fc73b7/pipeline.log\">pipeline</a>"]},{"id":"2111ad08-e343-47dd-a22b-1814bb7fdcc2","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1040.271301,"created":"2025-05-23T07:14:32.065687","updated":"2025-05-23T07:14:32.065693","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2111ad08-e343-47dd-a22b-1814bb7fdcc2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2111ad08-e343-47dd-a22b-1814bb7fdcc2/pipeline.log\">pipeline</a>"]},{"id":"c965a226-426d-4363-b95d-862e254de354","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1003.862195,"created":"2025-05-23T07:14:30.932407","updated":"2025-05-23T07:14:30.932412","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c965a226-426d-4363-b95d-862e254de354\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c965a226-426d-4363-b95d-862e254de354/pipeline.log\">pipeline</a>"]},{"id":"f8f32ff3-74c0-46fc-8fa9-91bbb41f7f01","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1051.341204,"created":"2025-05-23T07:14:28.333068","updated":"2025-05-23T07:14:28.333075","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8f32ff3-74c0-46fc-8fa9-91bbb41f7f01\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8f32ff3-74c0-46fc-8fa9-91bbb41f7f01/pipeline.log\">pipeline</a>"]}]} -->