### PR TITLE
Update container common sripts

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -1,8 +1,8 @@
-name: Auto Merge Scheduled / On Demand
+name: Auto Merge On Demand
 on:
-  schedule:
-    # Workflow runs every 45 minutes
-    - cron: '*/45 * * * *'
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       pr-number:
@@ -16,7 +16,10 @@ permissions:
 jobs:
   # Get all open PRs
   gather-pull-requests:
-    if: github.repository_owner == 'sclorg'
+    if: |
+      github.repository_owner == 'sclorg'
+      || (contains(github.event.comment.body, '/auto-merge')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:
@@ -44,7 +47,7 @@ jobs:
         name: Parse manual input
         run: |
           # shellcheck disable=SC2086
-          echo "result="[ ${{ inputs.pr-number }} ]"" >> $GITHUB_OUTPUT
+          echo "result="[ ${{ github.event.issue.number }} ]"" >> $GITHUB_OUTPUT
         shell: bash
 
   validate-pr:


### PR DESCRIPTION
It updates container-common-scripts to the latest.

It removes 'auto-merge-on-demand' that run each 45 minutes, but let's call it on request.



<!-- issue-commentator = {"comment-id":"2916248237"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2916211136","data":[{"id":"c24b142a-5b32-488a-b1ff-5e9360c617f3","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":416.699025,"created":"2025-05-28T12:48:15.271139","updated":"2025-05-28T12:48:15.271145","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c24b142a-5b32-488a-b1ff-5e9360c617f3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c24b142a-5b32-488a-b1ff-5e9360c617f3/pipeline.log\">pipeline</a>"]},{"id":"53585465-7949-412f-899e-ce4db17fcef4","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1551.024723,"created":"2025-05-28T12:31:40.028493","updated":"2025-05-28T12:31:40.028500","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53585465-7949-412f-899e-ce4db17fcef4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53585465-7949-412f-899e-ce4db17fcef4/pipeline.log\">pipeline</a>"]},{"id":"3047cd18-e983-4d1a-b607-0002a63de5db","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1461.480419,"created":"2025-05-28T12:36:03.486290","updated":"2025-05-28T12:36:03.486296","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3047cd18-e983-4d1a-b607-0002a63de5db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3047cd18-e983-4d1a-b607-0002a63de5db/pipeline.log\">pipeline</a>"]},{"id":"72deb0e4-6b82-45ad-8b8e-3e36954e70f1","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1129.418669,"created":"2025-05-28T12:44:55.149193","updated":"2025-05-28T12:44:55.149199","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/72deb0e4-6b82-45ad-8b8e-3e36954e70f1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/72deb0e4-6b82-45ad-8b8e-3e36954e70f1/pipeline.log\">pipeline</a>"]},{"id":"5b425f13-f3cf-4c78-b332-c60b07026e54","name":"RHEL10 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":726.379926,"created":"2025-05-28T12:55:00.896780","updated":"2025-05-28T12:55:00.896785","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b425f13-f3cf-4c78-b332-c60b07026e54\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b425f13-f3cf-4c78-b332-c60b07026e54/pipeline.log\">pipeline</a>"]},{"id":"0dbfe605-8ba2-40bb-a4b6-a0e6c443c9e0","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":544.892187,"created":"2025-05-28T12:59:11.069477","updated":"2025-05-28T12:59:11.069491","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0dbfe605-8ba2-40bb-a4b6-a0e6c443c9e0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0dbfe605-8ba2-40bb-a4b6-a0e6c443c9e0/pipeline.log\">pipeline</a>"]},{"id":"2aeb7584-3e9d-46c6-b509-1f5a1bcf7a93","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":989.699902,"created":"2025-05-28T12:58:25.237764","updated":"2025-05-28T12:58:25.237770","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2aeb7584-3e9d-46c6-b509-1f5a1bcf7a93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2aeb7584-3e9d-46c6-b509-1f5a1bcf7a93/pipeline.log\">pipeline</a>"]},{"id":"dd896168-66ab-498f-ba2f-d2027d3320bc","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1045.765575,"created":"2025-05-28T12:58:01.741223","updated":"2025-05-28T12:58:01.741231","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dd896168-66ab-498f-ba2f-d2027d3320bc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dd896168-66ab-498f-ba2f-d2027d3320bc/pipeline.log\">pipeline</a>"]},{"id":"20134116-5341-4258-9507-2b075ab1b8e3","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":609.842547,"created":"2025-05-28T13:07:55.936090","updated":"2025-05-28T13:07:55.936103","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/20134116-5341-4258-9507-2b075ab1b8e3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/20134116-5341-4258-9507-2b075ab1b8e3/pipeline.log\">pipeline</a>"]},{"id":"f0747184-da3a-4d41-a9d4-70c6175eb320","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1171.933103,"created":"2025-05-28T13:01:25.366822","updated":"2025-05-28T13:01:25.366830","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0747184-da3a-4d41-a9d4-70c6175eb320\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0747184-da3a-4d41-a9d4-70c6175eb320/pipeline.log\">pipeline</a>"]},{"id":"386df7ad-8795-4545-9127-1e7b25a215f4","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":1166.993912,"created":"2025-05-28T13:02:11.447499","updated":"2025-05-28T13:02:11.447508","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/386df7ad-8795-4545-9127-1e7b25a215f4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/386df7ad-8795-4545-9127-1e7b25a215f4/pipeline.log\">pipeline</a>"]},{"id":"e2403d77-16ad-471d-8efb-24b5f4cfc836","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":555.368762,"created":"2025-05-28T13:15:56.089304","updated":"2025-05-28T13:15:56.089310","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e2403d77-16ad-471d-8efb-24b5f4cfc836\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e2403d77-16ad-471d-8efb-24b5f4cfc836/pipeline.log\">pipeline</a>"]},{"id":"23184e46-1d7e-451c-bf0f-879c61c42baa","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1372.025028,"created":"2025-05-28T13:03:35.299732","updated":"2025-05-28T13:03:35.299739","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/23184e46-1d7e-451c-bf0f-879c61c42baa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/23184e46-1d7e-451c-bf0f-879c61c42baa/pipeline.log\">pipeline</a>"]},{"id":"a6780f57-edbd-42f0-977f-5a95beddfac2","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1115.118863,"created":"2025-05-28T13:09:53.290466","updated":"2025-05-28T13:09:53.290473","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6780f57-edbd-42f0-977f-5a95beddfac2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6780f57-edbd-42f0-977f-5a95beddfac2/pipeline.log\">pipeline</a>"]},{"id":"5b84405e-59c7-4e64-9183-45b1704e8243","name":"RHEL8 - OpenShift 4 - 10.5","runTime":1347.880029,"created":"2025-05-29T05:38:26.393781","updated":"2025-05-29T05:38:26.393788","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b84405e-59c7-4e64-9183-45b1704e8243\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b84405e-59c7-4e64-9183-45b1704e8243/pipeline.log\">pipeline</a>"]},{"id":"92f0b019-f683-4413-9c00-6bd07347b79d","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1078.372383,"created":"2025-05-28T13:15:16.796522","updated":"2025-05-28T13:15:16.796532","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/92f0b019-f683-4413-9c00-6bd07347b79d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/92f0b019-f683-4413-9c00-6bd07347b79d/pipeline.log\">pipeline</a>"]}]} -->