### PR TITLE
Fix expression ${OS%[0-9]*} so it works with rhel10.

### DIFF
--- a/test/test-lib-mysql.sh
+++ b/test/test-lib-mysql.sh
@@ -117,7 +117,8 @@ function test_mariadb_integration() {
   TEMPLATES="mariadb-ephemeral-template.json
   mariadb-persistent-template.json"
   SHORT_VERSION="${VERSION//.}"
-  namespace_image="${OS}/mariadb-${SHORT_VERSION}"
+  # MariaDB-103 exists only for RHEL8 and MariaDB exists only for all versions so let's use version 10.5
+  namespace_image="${OS}/mariadb-105"
   # Check if the current version is already GA
   # This directory is cloned from TMT plan repo 'sclorg-tmt-plans'
   local devel_file="/root/sclorg-tmt-plans/devel_images"
@@ -161,7 +162,7 @@ function test_mariadb_imagestream() {
   TEMPLATES="mariadb-ephemeral-template.json
   mariadb-persistent-template.json"
   for template in $TEMPLATES; do
-    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/examples/${template}" mariadb "-p MARIADB_VERSION=${VERSION}${tag}"
+    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS//[0-9]/}.json" "${THISDIR}/examples/${template}" mariadb "-p MARIADB_VERSION=${VERSION}${tag}"
   done
 }
 
@@ -178,7 +179,7 @@ function test_mariadb_template() {
   TEMPLATES="mariadb-ephemeral-template.json
   mariadb-persistent-template.json"
   for template in $TEMPLATES; do
-    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS%[0-9]*}.json" "${THISDIR}/examples/${template}" mariadb
+    ct_os_test_image_stream_template "${THISDIR}/imagestreams/mariadb-${OS//[0-9]/}.json" "${THISDIR}/examples/${template}" mariadb
   done
 }
 


### PR DESCRIPTION
Fix expression ${OS%[0-9]*} so it works with rhel10.

But in case of rhel10 it replaces to rhel1 that in templates the file rhel1.yaml does not exist.

<!-- issue-commentator = {"comment-id":"2929539539"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2929628713","data":[{"id":"cc9b7496-f29c-4fa3-817b-45d5df4fc34c","name":"RHEL8 - OpenShift 4 - 10.3","status":"complete","outcome":"passed","runTime":1381.472442,"created":"2025-06-02T08:57:37.338254","updated":"2025-06-02T08:57:37.338259","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc9b7496-f29c-4fa3-817b-45d5df4fc34c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc9b7496-f29c-4fa3-817b-45d5df4fc34c/pipeline.log\">pipeline</a>"]},{"id":"77416860-7242-4a08-bb1e-c913e596b8a8","name":"RHEL9 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1317.350502,"created":"2025-06-02T09:03:00.153356","updated":"2025-06-02T09:03:00.153362","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/77416860-7242-4a08-bb1e-c913e596b8a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/77416860-7242-4a08-bb1e-c913e596b8a8/pipeline.log\">pipeline</a>"]},{"id":"14e9163f-749d-481c-ad44-046d4b665726","name":"RHEL10 - OpenShift 4 - 10.11","runTime":657.891763,"created":"2025-06-02T09:58:24.322533","updated":"2025-06-02T09:58:24.322540","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/14e9163f-749d-481c-ad44-046d4b665726\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/14e9163f-749d-481c-ad44-046d4b665726/pipeline.log\">pipeline</a>"]},{"id":"b2ae47ac-2de9-49ec-a0b3-38fe712c9e73","name":"RHEL8 - OpenShift 4 - 10.5","status":"complete","outcome":"passed","runTime":1084.747075,"created":"2025-06-02T09:18:52.139947","updated":"2025-06-02T09:18:52.139956","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2ae47ac-2de9-49ec-a0b3-38fe712c9e73\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2ae47ac-2de9-49ec-a0b3-38fe712c9e73/pipeline.log\">pipeline</a>"]},{"id":"da3d83de-4ffa-4354-b14d-58422388dc26","name":"RHEL9 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1202.48284,"created":"2025-06-02T09:21:57.428008","updated":"2025-06-02T09:21:57.428016","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da3d83de-4ffa-4354-b14d-58422388dc26\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da3d83de-4ffa-4354-b14d-58422388dc26/pipeline.log\">pipeline</a>"]},{"id":"16dd0b64-49df-4767-b1b2-ecf51eac10b6","name":"RHEL8 - OpenShift 4 - 10.11","status":"complete","outcome":"passed","runTime":1086.090919,"created":"2025-06-02T09:24:27.120430","updated":"2025-06-02T09:24:27.120438","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/16dd0b64-49df-4767-b1b2-ecf51eac10b6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/16dd0b64-49df-4767-b1b2-ecf51eac10b6/pipeline.log\">pipeline</a>"]}]} -->