### PR TITLE
Fixes the creation of the root user when using password policies

### DIFF
--- a/root-common/usr/share/container-scripts/mysql/common.sh
+++ b/root-common/usr/share/container-scripts/mysql/common.sh
@@ -163,8 +163,9 @@ EOSQL
   if [ -v MYSQL_ROOT_PASSWORD ]; then
     log_info "Setting password for MySQL root user ..."
     if [ "$MYSQL_VERSION" \> "10.0" ] ; then
+    # use a password here, because otherwise a password policy can reject the creation of the root user
 mysql $mysql_flags <<EOSQL
-      CREATE USER IF NOT EXISTS 'root'@'%';
+      CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
 EOSQL
     fi
 mysql $mysql_flags <<EOSQL


### PR DESCRIPTION
Use a password in "CREATE USER IF NOT EXISTS 'root'@'%'", because otherwise a password policy can reject the creation of the root user.

Resolves https://github.com/sclorg/mariadb-container/issues/283

<!-- issue-commentator = {"comment-id":"3117007376"} -->