### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -32,7 +32,6 @@ LABEL summary="${SUMMARY}" \
       io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
       com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
       name="rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279163939"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279252938","data":[{"id":"3b3c5422-9fac-481c-9157-48b5ef8370eb","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":467.808931,"created":"2025-09-12T10:05:53.177002","updated":"2025-09-12T10:05:53.177007","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3b3c5422-9fac-481c-9157-48b5ef8370eb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3b3c5422-9fac-481c-9157-48b5ef8370eb/pipeline.log\">pipeline</a>"]},{"id":"c9ee2a78-40ca-4b0c-bda6-e53b07238e78","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":609.41125,"created":"2025-09-12T10:20:27.141624","updated":"2025-09-12T10:20:27.141630","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c9ee2a78-40ca-4b0c-bda6-e53b07238e78\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c9ee2a78-40ca-4b0c-bda6-e53b07238e78/pipeline.log\">pipeline</a>"]},{"id":"bc003432-be80-446f-a4bf-54cb7feb7833","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":624.502988,"created":"2025-09-12T10:21:05.512082","updated":"2025-09-12T10:21:05.512089","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bc003432-be80-446f-a4bf-54cb7feb7833\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bc003432-be80-446f-a4bf-54cb7feb7833/pipeline.log\">pipeline</a>"]},{"id":"e6e25f82-4f88-449f-9600-9082dbd9f49d","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":697.185921,"created":"2025-09-12T09:57:47.650821","updated":"2025-09-12T09:57:47.650827","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e6e25f82-4f88-449f-9600-9082dbd9f49d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e6e25f82-4f88-449f-9600-9082dbd9f49d/pipeline.log\">pipeline</a>"]},{"id":"e9e1e151-5058-4d0d-b4b0-4fd664633b41","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":903.886391,"created":"2025-09-12T09:59:56.139528","updated":"2025-09-12T09:59:56.139535","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e9e1e151-5058-4d0d-b4b0-4fd664633b41\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e9e1e151-5058-4d0d-b4b0-4fd664633b41/pipeline.log\">pipeline</a>"]},{"id":"8285b6da-590a-4c5e-9017-8c15d9dd8b8f","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1074.473981,"created":"2025-09-12T10:14:07.525616","updated":"2025-09-12T10:14:07.525622","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8285b6da-590a-4c5e-9017-8c15d9dd8b8f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8285b6da-590a-4c5e-9017-8c15d9dd8b8f/pipeline.log\">pipeline</a>"]},{"id":"fc7298f5-21d1-4155-a7cb-8698dcd1c637","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":1090.601854,"created":"2025-09-12T09:53:19.519619","updated":"2025-09-12T09:53:19.519626","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc7298f5-21d1-4155-a7cb-8698dcd1c637\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc7298f5-21d1-4155-a7cb-8698dcd1c637/pipeline.log\">pipeline</a>"]},{"id":"890823ea-83ba-4fb3-bce3-4a5fa4f8f90e","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1281.827693,"created":"2025-09-12T09:56:58.046100","updated":"2025-09-12T09:56:58.046144","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/890823ea-83ba-4fb3-bce3-4a5fa4f8f90e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/890823ea-83ba-4fb3-bce3-4a5fa4f8f90e/pipeline.log\">pipeline</a>"]},{"id":"b51de119-49f5-4873-af96-9176810388db","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":1055.773529,"created":"2025-09-12T10:20:00.649870","updated":"2025-09-12T10:20:00.649876","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b51de119-49f5-4873-af96-9176810388db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b51de119-49f5-4873-af96-9176810388db/pipeline.log\">pipeline</a>"]},{"id":"879f9c0a-385d-44b1-8851-0827a6081558","name":"RHEL9 - 10.11","runTime":1269.007166,"created":"2025-09-12T10:19:48.262530","updated":"2025-09-12T10:19:48.262538","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/879f9c0a-385d-44b1-8851-0827a6081558\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/879f9c0a-385d-44b1-8851-0827a6081558/pipeline.log\">pipeline</a>"]}]} -->