### PR TITLE
Update the mariadb 11.8 README

### DIFF
--- a/11.8/root/usr/share/container-scripts/mysql/README.md
+++ b/11.8/root/usr/share/container-scripts/mysql/README.md
@@ -50,7 +50,6 @@ or if it was already present, `mysqld` is executed and will run as PID 1. You ca
 
 Environment variables and volumes
 ---------------------------------
-<!--- TODO: review if correct -->
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
@@ -289,7 +288,6 @@ or a new container image can be built using s2i.
 
 Upgrading and data directory version checking
 ---------------------------------------------
-<!--- TODO: review if still true -->
 MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
 For version changes in Z part, the server's binary data format stays compatible and thus no
 special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual


### PR DESCRIPTION
11.8 is only available for Fedora right now, so I commented out all RHEL-related information until a RHEL/CentOS Stream container is released. It should be easy to put everything back after that.

I'm also not sure about the `Upgrading and data directory version checking` section. Maybe it should be updated everywhere...

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"3360160579"} -->