### PR TITLE
This pull request enables dist-gen for mariadb-container

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,14 +38,6 @@ jobs:
             tag: "c9s"
             image_name: "mariadb-105-c9s"
 
-          - dockerfile: "10.5/Dockerfile.fedora"
-            docker_context: "10.5"
-            registry_namespace: "fedora"
-            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
-            tag: "fedora"
-            image_name: "mariadb-105"
-
           - dockerfile: "10.11/Dockerfile.fedora"
             docker_context: "10.11"
             registry_namespace: "fedora"

--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -45,7 +45,6 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -19,23 +19,24 @@ ENV VERSION="${MYSQL_VERSION}" \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     ARCH=x86_64 \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c10s" \
+      io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
+      com.redhat.component="${NAME}-1011-c10s" \
+      name="sclorg/${NAME}-1011-c10s" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c10s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-1011-c10s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -45,6 +46,7 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
@@ -54,14 +56,14 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.11/root-common /
+COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.11/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.c10s
+++ b/10.11/Dockerfile.c10s
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
-      com.redhat.component="${NAME}-1011-c10s" \
-      name="sclorg/${NAME}-1011-c10s" \
-      version="1" \
+      com.redhat.component="mariadb-1011-c10s" \
+      name="sclorg/mariadb-1011-c10s" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-1011-c10s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-1011-c10s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,14 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -12,29 +12,31 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011  
+    MYSQL_SHORT_VERSION=1011
 
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
+      io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
+      com.redhat.component="${NAME}-1011-c9s" \
+      name="sclorg/${NAME}-1011-c9s" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-1011-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -42,9 +44,9 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+RUN yum -y module enable mariadb:10.11 && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     yum -y clean all --enablerepo='*' && \
@@ -55,14 +57,14 @@ RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.11/root-common /
+COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.11/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -43,7 +43,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:10.11 && \
+RUN dnf -y module enable mariadb:10.11 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
-      com.redhat.component="${NAME}-1011-c9s" \
-      name="sclorg/${NAME}-1011-c9s" \
-      version="1" \
+      com.redhat.component="mariadb-1011-c9s" \
+      name="sclorg/mariadb-1011-c9s" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-1011-c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-1011-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -45,14 +44,13 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable mariadb:10.11 && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.11/Dockerfile.c9s
+++ b/10.11/Dockerfile.c9s
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:10.11 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -20,7 +20,7 @@ ENV VERSION="${MYSQL_VERSION}" \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     ARCH=x86_64 \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,12 +29,11 @@ MariaDB databases on behalf of the clients."
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
       com.redhat.component="${NAME}" \
       name="fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
-      version="${MYSQL_VERSION}" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -56,9 +55,9 @@ RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.11/root-common /
+COPY 10.11/s2i-common/bin/ ${STI_SCRIPTS_PATH}
+COPY 10.11/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error

--- a/10.11/Dockerfile.fedora
+++ b/10.11/Dockerfile.fedora
@@ -12,7 +12,8 @@ FROM quay.io/fedora/s2i-core:42
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011  
+    MYSQL_SHORT_VERSION=1011
+
 
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -45,7 +45,6 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -12,28 +12,30 @@ FROM ubi10/s2i-core
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011  
+    MYSQL_SHORT_VERSION=1011
 
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
+      io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
+      com.redhat.component="${NAME}-1011-container" \
+      name="rhel10/${NAME}-1011" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-1011" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -43,6 +45,7 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
@@ -52,14 +55,14 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.11/root-common /
+COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.11/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.rhel10
+++ b/10.11/Dockerfile.rhel10
@@ -32,10 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
-      com.redhat.component="${NAME}-1011-container" \
-      name="rhel10/${NAME}-1011" \
+      com.redhat.component="mariadb-1011-container" \
+      name="rhel10/mariadb-1011" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-1011" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/mariadb-1011" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -43,14 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -10,25 +10,32 @@ FROM ubi8/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
+    MYSQL_SHORT_VERSION=1011
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
+    NAME=mariadb \
+    ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
-LABEL summary="$SUMMARY" \
-      description="$DESCRIPTION" \
-      io.k8s.description="$DESCRIPTION" \
+# Standalone ENV call so these values can be re-used in the other ENV calls
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
       io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
-      com.redhat.component="mariadb-1011-container" \
-      name="rhel8/mariadb-1011" \
+      com.redhat.component="${NAME}-1011-container" \
+      name="rhel8/${NAME}-1011" \
       version="1" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-1011" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -36,13 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base mariadb-server" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
+RUN yum -y module enable mariadb:10.11 && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
+    rpm -V ${INSTALL_PKGS} && \
+    /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql:root /var/lib/mysql && \
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -43,7 +43,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:10.11 && \
+RUN dnf -y module enable mariadb:10.11 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -32,10 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
-      com.redhat.component="${NAME}-1011-container" \
-      name="rhel8/${NAME}-1011" \
-      version="1" \
+      com.redhat.component="mariadb-1011-container" \
+      name="rhel8/mariadb-1011" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-1011" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,14 +44,13 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum -y module enable mariadb:10.11 && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.11/Dockerfile.rhel8
+++ b/10.11/Dockerfile.rhel8
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:10.11 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
-      com.redhat.component="${NAME}-1011-container" \
-      name="rhel9/${NAME}-1011" \
-      version="1" \
+      com.redhat.component="mariadb-1011-container" \
+      name="rhel9/mariadb-1011" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-1011" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/mariadb-1011" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -45,14 +44,13 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN dnf -y module enable mariadb:10.11 && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -12,29 +12,31 @@ FROM ubi9/s2i-core
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.11 \
-    MYSQL_SHORT_VERSION=1011  
+    MYSQL_SHORT_VERSION=1011
 
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.11 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.11" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
+      io.openshift.tags="database,mysql,mariadb,mariadb1011,mariadb-1011" \
+      com.redhat.component="${NAME}-1011-container" \
+      name="rhel9/${NAME}-1011" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-1011" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -42,12 +44,12 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+RUN dnf -y module enable mariadb:10.11 && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
@@ -55,14 +57,14 @@ RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.11/root-common /
+COPY 10.11/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.11/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.11/Dockerfile.rhel9
+++ b/10.11/Dockerfile.rhel9
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:10.11 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.11/root/usr/share/container-scripts/mysql/README.md
+++ b/10.11/root/usr/share/container-scripts/mysql/README.md
@@ -200,7 +200,7 @@ For this, we will assume that you are using the `rhel10/mariadb-1011` image,
 available via `mariadb:10.11` imagestream tag in Openshift.
 
 
-For example, to build a customized MariaDB database image `my-mariadb-rhel8`
+For example, to build a customized MariaDB database image `my-mariadb-rhel10`
 with a configuration from `https://github.com/sclorg/mariadb-container/tree/master/examples/extend-image` run:
 
 ```

--- a/10.11/root/usr/share/container-scripts/mysql/README.md
+++ b/10.11/root/usr/share/container-scripts/mysql/README.md
@@ -295,8 +295,7 @@ special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider do
 steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-from-mariadb-10-6-to-mariadb-10-11
 
-Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported; the only exception is upgrading from MariaDB 10.6 to MariaDB 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/10.11/root/usr/share/container-scripts/mysql/README.md
+++ b/10.11/root/usr/share/container-scripts/mysql/README.md
@@ -2,10 +2,13 @@ MariaDB 10.11 SQL Database Server Container image
 =============================================
 
 This container image includes MariaDB 10.11 SQL database server for OpenShift and general usage.
-Users can choose between RHEL, CentOS Stream and Fedora based images.
+
+<!---Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
 the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
-and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
+and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).-->
+
+Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README call `podman`, you can replace any such calls by `docker` with the same arguments
@@ -286,12 +289,11 @@ or a new container image can be built using s2i.
 
 Upgrading and data directory version checking
 ---------------------------------------------
-
 MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
 For version changes in Z part, the server's binary data format stays compatible and thus no
 special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
 steps as described at
-https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/
+https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-from-mariadb-10-6-to-mariadb-10-11
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
 the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.

--- a/10.11/root/usr/share/container-scripts/mysql/README.md
+++ b/10.11/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,7 @@ steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-from-mariadb-10-6-to-mariadb-10-11
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/10.3/Dockerfile.rhel8
+++ b/10.3/Dockerfile.rhel8
@@ -10,25 +10,32 @@ FROM ubi8/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.3 \
+    MYSQL_SHORT_VERSION=103
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
+    NAME=mariadb \
+    ARCH=x86_64 \
     SUMMARY="MariaDB 10.3 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
-LABEL summary="$SUMMARY" \
-      description="$DESCRIPTION" \
-      io.k8s.description="$DESCRIPTION" \
+# Standalone ENV call so these values can be re-used in the other ENV calls
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
       io.k8s.display-name="MariaDB 10.3" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb103,mariadb-103" \
-      com.redhat.component="mariadb-103-container" \
-      name="rhel8/mariadb-103" \
+      com.redhat.component="${NAME}-103-container" \
+      name="rhel8/${NAME}-103" \
       version="1" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-103" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -36,13 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base mariadb-server" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
+RUN yum -y module enable mariadb:10.3 && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    rpm -V ${INSTALL_PKGS} && \
+    /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
@@ -56,7 +63,7 @@ COPY 10.3/root /
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /bin/run-mysqld $STI_SCRIPTS_PATH/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.3/Dockerfile.rhel8
+++ b/10.3/Dockerfile.rhel8
@@ -32,10 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.3" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb103,mariadb-103" \
-      com.redhat.component="${NAME}-103-container" \
-      name="rhel8/${NAME}-103" \
-      version="1" \
+      com.redhat.component="mariadb-103-container" \
+      name="rhel8/mariadb-103" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-103" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -45,13 +45,12 @@ EXPOSE 3306
 # to make sure of that.
 RUN yum -y module enable mariadb:10.3 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.3/Dockerfile.rhel8
+++ b/10.3/Dockerfile.rhel8
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:10.3 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.3/Dockerfile.rhel8
+++ b/10.3/Dockerfile.rhel8
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.3 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.3/Dockerfile.rhel8
+++ b/10.3/Dockerfile.rhel8
@@ -43,7 +43,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:10.3 && \
+RUN dnf -y module enable mariadb:10.3 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/10.3/root/usr/share/container-scripts/mysql/README.md
+++ b/10.3/root/usr/share/container-scripts/mysql/README.md
@@ -295,8 +295,7 @@ special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider do
 steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-103-to-mariadb-104
 
-Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported; the only exception is upgrading from MariaDB 10.3 to 10.5.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/10.3/root/usr/share/container-scripts/mysql/README.md
+++ b/10.3/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,7 @@ steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-103-to-mariadb-104
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/10.3/root/usr/share/container-scripts/mysql/README.md
+++ b/10.3/root/usr/share/container-scripts/mysql/README.md
@@ -1,8 +1,14 @@
-MariaDB 10.3 SQL Database Server Docker image
+MariaDB 10.3 SQL Database Server Container image
 =============================================
 
 This container image includes MariaDB 10.3 SQL database server for OpenShift and general usage.
-The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+
+<!---Users can choose between RHEL, CentOS and Fedora based images.
+The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
+and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).-->
+
+Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README call `podman`, you can replace any such calls by `docker` with the same arguments
@@ -283,15 +289,14 @@ or a new container image can be built using s2i.
 
 Upgrading and data directory version checking
 ---------------------------------------------
-
 MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
 For version changes in Z part, the server's binary data format stays compatible and thus no
 special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
 steps as described at
-https://mariadb.com/kb/en/library/upgrading-from-mariadb-102-to-mariadb-103/
+https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-103-to-mariadb-104
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0.
+the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.
@@ -357,4 +362,9 @@ See also
 --------
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
-In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8.
+In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
+the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
+and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.5 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.5" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
-      com.redhat.component="${NAME}-105-c9s" \
-      name="sclorg/${NAME}-105-c9s" \
-      version="1" \
+      com.redhat.component="mariadb-105-c9s" \
+      name="sclorg/mariadb-105-c9s" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-105-c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-105-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,15 +43,14 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module disable mariadb && \
+RUN dnf -y module disable mariadb && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -12,29 +12,31 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=105  
+    MYSQL_SHORT_VERSION=105
 
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.5 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.5" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
+      io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
+      com.redhat.component="${NAME}-105-c9s" \
+      name="sclorg/${NAME}-105-c9s" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-105-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -42,27 +44,27 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module disable ${NAME} && \
+RUN yum -y module disable mariadb && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p ${HOME}/data && chown -R mysql.0 ${HOME} && \
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.5/root-common /
+COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.5/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.c9s
+++ b/10.5/Dockerfile.c9s
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module disable mariadb && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -32,10 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.5" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
-      com.redhat.component="${NAME}-105-container" \
-      name="rhel8/${NAME}-105" \
-      version="1" \
+      com.redhat.component="mariadb-105-container" \
+      name="rhel8/mariadb-105" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-105" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -45,13 +45,12 @@ EXPOSE 3306
 # to make sure of that.
 RUN yum -y module enable mariadb:10.5 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.5 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -10,25 +10,32 @@ FROM ubi8/s2i-core
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.5 \
+    MYSQL_SHORT_VERSION=105
+
+ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
+    NAME=mariadb \
+    ARCH=x86_64 \
     SUMMARY="MariaDB 10.5 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
-LABEL summary="$SUMMARY" \
-      description="$DESCRIPTION" \
-      io.k8s.description="$DESCRIPTION" \
+# Standalone ENV call so these values can be re-used in the other ENV calls
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
       io.k8s.display-name="MariaDB 10.5" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
-      com.redhat.component="mariadb-105-container" \
-      name="rhel8/mariadb-105" \
+      com.redhat.component="${NAME}-105-container" \
+      name="rhel8/${NAME}-105" \
       version="1" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel8/mariadb-105" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -36,13 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:$MYSQL_VERSION && \
-    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base mariadb-server" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    /usr/libexec/mysqld -V | grep -qe "$MYSQL_VERSION\." && echo "Found VERSION $MYSQL_VERSION" && \
+RUN yum -y module enable mariadb:10.5 && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    rpm -V ${INSTALL_PKGS} && \
+    /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     yum -y clean all --enablerepo='*' && \
-    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -43,7 +43,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:10.5 && \
+RUN dnf -y module enable mariadb:10.5 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/10.5/Dockerfile.rhel8
+++ b/10.5/Dockerfile.rhel8
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:10.5 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -12,29 +12,31 @@ FROM ubi9/s2i-core
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION=10.5 \
-    MYSQL_SHORT_VERSION=105 
+    MYSQL_SHORT_VERSION=105
 
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 10.5 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 10.5" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
+      io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
+      com.redhat.component="${NAME}-105-container" \
+      name="rhel9/${NAME}-105" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-105" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -43,25 +45,25 @@ EXPOSE 3306
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
-    mkdir -p ${HOME}/data && chown -R mysql.0 ${HOME} && \
+    dnf -y clean all --enablerepo='*' && \
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 10.5/root-common /
+COPY 10.5/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 10.5/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 10.5 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 10.5" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb105,mariadb-105" \
-      com.redhat.component="${NAME}-105-container" \
-      name="rhel9/${NAME}-105" \
-      version="1" \
+      com.redhat.component="mariadb-105-container" \
+      name="rhel9/mariadb-105" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-105" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/mariadb-105" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -51,7 +50,6 @@ RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/10.5/Dockerfile.rhel9
+++ b/10.5/Dockerfile.rhel9
@@ -45,7 +45,6 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/10.5/root/usr/share/container-scripts/mysql/README.md
+++ b/10.5/root/usr/share/container-scripts/mysql/README.md
@@ -1,10 +1,14 @@
-MariaDB 10.5 SQL Database Server Docker image
+MariaDB 10.5 SQL Database Server Container image
 =============================================
 
 This container image includes MariaDB 10.5 SQL database server for OpenShift and general usage.
-Users can choose between RHEL and CentOS Stream based images.
+
+<!---Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-and the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg).
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
+and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).-->
+
+Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README call `podman`, you can replace any such calls by `docker` with the same arguments
@@ -285,15 +289,14 @@ or a new container image can be built using s2i.
 
 Upgrading and data directory version checking
 ---------------------------------------------
-
 MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
 For version changes in Z part, the server's binary data format stays compatible and thus no
 special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
 steps as described at
-https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-105/
+https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-4-to-mariadb-10-5
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.5.
+the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.
@@ -360,5 +363,8 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
 In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
-the Dockerfile for RHEL9 is called Dockerfile.rhel9
-and the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s.
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
+the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
+and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/10.5/root/usr/share/container-scripts/mysql/README.md
+++ b/10.5/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,7 @@ steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-4-to-mariadb-10-5
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/10.5/root/usr/share/container-scripts/mysql/README.md
+++ b/10.5/root/usr/share/container-scripts/mysql/README.md
@@ -295,8 +295,7 @@ special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider do
 steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-4-to-mariadb-10-5
 
-Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported; the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.5.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/11.8/Dockerfile.c10s
+++ b/11.8/Dockerfile.c10s
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
-      com.redhat.component="${NAME}-118-c10s" \
-      name="sclorg/${NAME}-118-c10s" \
-      version="1" \
+      com.redhat.component="mariadb-118-c10s" \
+      name="sclorg/mariadb-118-c10s" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-118-c10s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-118-c10s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,14 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/11.8/Dockerfile.c10s
+++ b/11.8/Dockerfile.c10s
@@ -19,23 +19,24 @@ ENV VERSION="${MYSQL_VERSION}" \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     ARCH=x86_64 \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c10s" \
+      io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
+      com.redhat.component="${NAME}-118-c10s" \
+      name="sclorg/${NAME}-118-c10s" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c10s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-118-c10s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -45,6 +46,7 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
@@ -54,14 +56,14 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 11.8/root-common /
+COPY 11.8/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 11.8/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/11.8/Dockerfile.c10s
+++ b/11.8/Dockerfile.c10s
@@ -45,7 +45,6 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/11.8/Dockerfile.c10s
+++ b/11.8/Dockerfile.c10s
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/11.8/Dockerfile.c9s
+++ b/11.8/Dockerfile.c9s
@@ -18,23 +18,25 @@ ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
+      io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
+      com.redhat.component="${NAME}-118-c9s" \
+      name="sclorg/${NAME}-118-c9s" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-${MYSQL_SHORT_VERSION}-c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-118-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -42,7 +44,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
+RUN yum -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
@@ -55,14 +57,14 @@ RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 11.8/root-common /
+COPY 11.8/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 11.8/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/11.8/Dockerfile.c9s
+++ b/11.8/Dockerfile.c9s
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
-      com.redhat.component="${NAME}-118-c9s" \
-      name="sclorg/${NAME}-118-c9s" \
-      version="1" \
+      com.redhat.component="mariadb-118-c9s" \
+      name="sclorg/mariadb-118-c9s" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-118-c9s" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/mariadb-118-c9s" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -46,13 +45,12 @@ EXPOSE 3306
 # to make sure of that.
 RUN yum -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/11.8/Dockerfile.c9s
+++ b/11.8/Dockerfile.c9s
@@ -43,7 +43,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable mariadb:11.8 && \
+RUN dnf -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/11.8/Dockerfile.c9s
+++ b/11.8/Dockerfile.c9s
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/11.8/Dockerfile.c9s
+++ b/11.8/Dockerfile.c9s
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/11.8/Dockerfile.fedora
+++ b/11.8/Dockerfile.fedora
@@ -20,7 +20,7 @@ ENV VERSION="${MYSQL_VERSION}" \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     ARCH=x86_64 \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,12 +29,11 @@ MariaDB databases on behalf of the clients."
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
       com.redhat.component="${NAME}" \
       name="fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
-      version="${MYSQL_VERSION}" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -56,9 +55,9 @@ RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 11.8/root-common /
+COPY 11.8/s2i-common/bin/ ${STI_SCRIPTS_PATH}
+COPY 11.8/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error

--- a/11.8/Dockerfile.fedora
+++ b/11.8/Dockerfile.fedora
@@ -14,6 +14,7 @@ FROM quay.io/fedora/s2i-core:42
 ENV MYSQL_VERSION=11.8 \
     MYSQL_SHORT_VERSION=118
 
+
 ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
@@ -54,7 +55,6 @@ RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
-
 
 COPY ${MYSQL_VERSION}/root-common /
 COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}

--- a/11.8/Dockerfile.rhel10
+++ b/11.8/Dockerfile.rhel10
@@ -18,23 +18,25 @@ ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
+      io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
+      com.redhat.component="${NAME}-118-container" \
+      name="rhel10/${NAME}-118" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-${MYSQL_SHORT_VERSION}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-118" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,6 +46,7 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
@@ -53,14 +56,14 @@ RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 11.8/root-common /
+COPY 11.8/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 11.8/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/11.8/Dockerfile.rhel10
+++ b/11.8/Dockerfile.rhel10
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
-      com.redhat.component="${NAME}-118-container" \
-      name="rhel10/${NAME}-118" \
-      version="1" \
+      com.redhat.component="mariadb-118-container" \
+      name="rhel10/mariadb-118" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/${NAME}-118" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/mariadb-118" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,14 +43,13 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/11.8/Dockerfile.rhel10
+++ b/11.8/Dockerfile.rhel10
@@ -45,7 +45,6 @@ EXPOSE 3306
 # to make sure of that.
 RUN INSTALL_PKGS="policycoreutils rsync tar xz gettext hostname groff-base ${NAME}${MYSQL_VERSION}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/11.8/Dockerfile.rhel10
+++ b/11.8/Dockerfile.rhel10
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/11.8/Dockerfile.rhel9
+++ b/11.8/Dockerfile.rhel9
@@ -32,11 +32,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
-      com.redhat.component="${NAME}-118-container" \
-      name="rhel9/${NAME}-118" \
-      version="1" \
+      com.redhat.component="mariadb-118-container" \
+      name="rhel9/mariadb-118" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-118" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/mariadb-118" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -46,13 +45,12 @@ EXPOSE 3306
 # to make sure of that.
 RUN dnf -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/11.8/Dockerfile.rhel9
+++ b/11.8/Dockerfile.rhel9
@@ -46,7 +46,6 @@ EXPOSE 3306
 RUN dnf -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/11.8/Dockerfile.rhel9
+++ b/11.8/Dockerfile.rhel9
@@ -21,11 +21,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \

--- a/11.8/Dockerfile.rhel9
+++ b/11.8/Dockerfile.rhel9
@@ -18,23 +18,25 @@ ENV VERSION="${MYSQL_VERSION}" \
     APP_DATA=/opt/app-root/src \
     HOME=/var/lib/mysql \
     NAME=mariadb \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB 11.8 SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-The mysqld server daemon accepts connections from clients and provides access to content from \
-MariaDB databases on behalf of the clients."
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
 
+# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB 11.8" \
       io.openshift.expose-services="3306:mysql" \
-      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
-      com.redhat.component="${NAME}-${MYSQL_SHORT_VERSION}-container" \
-      name="rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
+      io.openshift.tags="database,mysql,mariadb,mariadb118,mariadb-118" \
+      com.redhat.component="${NAME}-118-container" \
+      name="rhel9/${NAME}-118" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-${MYSQL_SHORT_VERSION}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel9/${NAME}-118" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -42,12 +44,12 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
+RUN dnf -y module enable mariadb:11.8 && \
     INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base ${NAME}-server" && \
     yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-    yum -y clean all --enablerepo='*' && \
+    dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
@@ -55,14 +57,14 @@ RUN yum -y module enable ${NAME}:${MYSQL_VERSION} && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY 11.8/root-common /
+COPY 11.8/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY 11.8/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error
 # /usr/libexec/s2i/run no such file or directory
-RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
 
 # this is needed due to issues with squash
 # when this directory gets rm'd by the container-setup

--- a/11.8/root/usr/share/container-scripts/mysql/README.md
+++ b/11.8/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,7 @@ steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/11.8/root/usr/share/container-scripts/mysql/README.md
+++ b/11.8/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,6 @@ steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/11.8/root/usr/share/container-scripts/mysql/README.md
+++ b/11.8/root/usr/share/container-scripts/mysql/README.md
@@ -25,14 +25,14 @@ You can find more information on the MariaDB project from the project Web site
 
 Usage
 -----
-<!--- TODO: change back to rhel10 when the image comes out -->
+
 For this, we will assume that you are using the MariaDB 11.8 container image from the
-Quay.io registry called `fedora/mariadb-118`.
+Red Hat Container Catalog called `rhel10/mariadb-118`.
 If you want to set only the mandatory environment variables and not store
 the database in a host directory, execute the following command:
 
 ```
-$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 fedora/mariadb-118
+$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 rhel10/mariadb-118
 ```
 
 This will create a container named `mariadb_database` running MySQL with database
@@ -50,6 +50,7 @@ or if it was already present, `mysqld` is executed and will run as PID 1. You ca
 
 Environment variables and volumes
 ---------------------------------
+
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
@@ -193,7 +194,7 @@ variable with the full path of the file you wish to use. For example, the defaul
 location is `/etc/my.cnf` but you can change it to `/etc/mysql/my.cnf` by setting
  `MYSQL_DEFAULTS_FILE=/etc/mysql/my.cnf`
 
-<!--- TODO: put back when the rhel/centos images are released
+
 Extending image
 ---------------
 This image can be extended in Openshift using the `Source` build strategy or via the standalone
@@ -265,7 +266,7 @@ every time the image is started using `podman run`. The directory has to be
 mounted into `/opt/app-root/src/` in the image
 (`-v ./image-configuration/:/opt/app-root/src/`).
 This overwrites customization built into the image.
--->
+
 
 Securing the connection with SSL
 --------------------------------
@@ -292,7 +293,7 @@ MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23)
 For version changes in Z part, the server's binary data format stays compatible and thus no
 special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
 steps as described at
-https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/
+https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
 the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
@@ -361,7 +362,7 @@ See also
 --------
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
-In that repository,
+In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
 the Dockerfile for RHEL9 is called Dockerfile.rhel9,
 the Dockerfile for RHEL10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,46 @@
+# Manifest for image directories creation
+# every dest path will be prefixed by $DESTDIR/$version
+
+# Files containing distgen directives
+DISTGEN_RULES:
+  - src: src/root/usr/share/container-scripts/mysql/README.md
+    dest: root/usr/share/container-scripts/mysql/README.md
+
+
+# Files containing distgen directives, which are used for each
+# (distro, version) combination not excluded in multispec
+DISTGEN_MULTI_RULES:
+  - src: src/Dockerfile
+    dest: Dockerfile.rhel8
+
+  - src: src/Dockerfile
+    dest: Dockerfile.rhel9
+
+  - src: src/Dockerfile
+    dest: Dockerfile.rhel10
+
+  - src: src/Dockerfile
+    dest: Dockerfile.c9s
+
+  - src: src/Dockerfile
+    dest: Dockerfile.c10s
+
+  - src: src/Dockerfile.fedora
+    dest: Dockerfile.fedora
+
+
+# Symbolic links
+# This section is the last one on purpose because the generator.py
+# does not allow dead symlinks.
+SYMLINK_RULES:
+  - src: ../root-common
+    dest: root-common
+
+  - src: ../s2i-common
+    dest: s2i-common
+
+  - src: ../test
+    dest: test
+
+  - src: root/usr/share/container-scripts/mysql/README.md
+    dest: README.md

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -25,7 +25,7 @@ specs:
       full_img_name: "rhel8/mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
       environment_setup:
-          yum -y module enable mariadb:{{ spec.version}} && \
+          dnf -y module enable mariadb:{{ spec.version}} && \
 
     rhel9:
       distros:
@@ -63,7 +63,7 @@ specs:
       com_redhat_component: "mariadb-{{ spec.short }}-{{ spec.prod }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
       environment_setup:
-          yum -y module enable mariadb:{{ spec.version }} && \
+          dnf -y module enable mariadb:{{ spec.version }} && \
 
     c10s:
       distros:

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -1,0 +1,132 @@
+version: 1
+
+specs:
+  distroinfo:
+    fedora42:
+      distros:
+        - fedora-42-x86_64
+      s2i_base: quay.io/fedora/s2i-core
+      s2i_base_tag: "42"
+      org: "fedora"
+      prod: "fedora"
+      img_name: "fedora/mariadb-{{ spec.short }}"
+      full_img_name: "quay.io/fedora/mariadb-{{ spec.short }}"
+      pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
+
+    rhel8:
+      distros:
+        - rhel-8-x86_64
+      s2i_base: ubi8/s2i-core
+      org: "rhel8"
+      prod: "rhel8"
+      img_name: "rhel8/mariadb-{{ spec.short }}"
+      pkgs: "policycoreutils rsync tar gettext hostname groff-base"
+      environment_setup: >-4
+          yum -y module enable mariadb:{{ spec.version}} && \
+
+    rhel9:
+      distros:
+        - rhel-9-x86_64
+      s2i_base: ubi9/s2i-core
+      org: "rhel9"
+      prod: "rhel9"
+      img_name: "rhel9/mariadb-{{ spec.short }}"
+      pkgs: "policycoreutils rsync tar gettext hostname groff-base"      
+      environment_setup: >-4
+          dnf -y module enable mariadb:{{ spec.version}} && \
+
+    rhel10:
+      distros:
+        - rhel-10-x86_64
+      s2i_base: ubi10/s2i-core
+      org: "rhel10"
+      prod: "rhel10"
+      img_name: "rhel10/mariadb-{{ spec.short }}"
+      pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
+
+    c9s:
+      distros:
+        - centos-stream-9-x86_64
+      s2i_base: quay.io/sclorg/s2i-core-c9s
+      s2i_base_tag: "c9s"
+      org: "sclorg"
+      prod: "c9s"
+      img_name: "sclorg/mariadb-{{ spec.short }}-c9s"
+      full_img_name: "quay.io/sclorg/mariadb-{{ spec.short }}-c9s"
+      pkgs: "policycoreutils rsync tar gettext hostname groff-base"
+      environment_setup: >-4
+          yum -y module enable mariadb:{{ spec.version }} && \
+
+    c10s:
+      distros:
+        - centos-stream-10-x86_64
+      s2i_base: quay.io/sclorg/s2i-core-c10s
+      s2i_base_tag: "c10s"
+      org: "sclorg"
+      prod: "c10s"
+      img_name: "sclorg/mariadb-{{ spec.short }}-c10s"
+      full_img_name: "quay.io/sclorg/mariadb-{{ spec.short }}-c10s"
+      pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
+
+  version:
+    "10.3":
+      version: "10.3"
+      short: "103"
+      rhel_image_name: "rhel8/mariadb-103"
+      s2i_example_name: "my-mariadb-rhel8"
+      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-102-to-mariadb-103/"
+      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0."
+
+    "10.5":
+      version: "10.5"
+      short: "105"
+      rhel_image_name: "rhel9/mariadb-105"
+      s2i_example_name: "my-mariadb-rhel9"
+      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-105/"
+      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.5."
+
+    "10.11":
+      version: "10.11"
+      short: "1011"
+      rhel_image_name: "rhel10/mariadb-1011"
+      s2i_example_name: "my-mariadb-rhel10"
+      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/"
+      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11."
+
+    "11.8":
+      version: "11.8"
+      short: "118"
+      rhel_image_name: "rhel10/mariadb-118"
+      s2i_example_name: "my-mariadb-rhel10"
+      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/"
+      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11."
+
+
+matrix:
+  include:
+    - version: "10.3"
+      distros:
+        - rhel-8-x86_64
+
+    - version: "10.5"
+      distros:
+        - rhel-8-x86_64
+        - rhel-9-x86_64
+        - centos-stream-9-x86_64
+
+    - version: "10.11"
+      distros:
+        - rhel-8-x86_64
+        - rhel-9-x86_64
+        - rhel-10-x86_64
+        - centos-stream-9-x86_64
+        - centos-stream-10-x86_64
+        - fedora-42-x86_64
+
+    - version: "11.8"
+      distros:
+        - rhel-9-x86_64
+        - rhel-10-x86_64
+        - centos-stream-9-x86_64
+        - centos-stream-10-x86_64
+        - fedora-42-x86_64

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -108,7 +108,7 @@ specs:
       rhel_image_name: "rhel10/mariadb-118"
       s2i_example_name: "my-mariadb-rhel10"
       upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0"
-      upgrade_skip_note: "Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;"
+      upgrade_skip_note: "Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported."
 
 
 matrix:

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -22,6 +22,7 @@ specs:
       prod: "rhel8"
       img_name: "rhel8/mariadb-{{ spec.short }}"
       com_redhat_component: "mariadb-{{ spec.short }}-container"
+      full_img_name: "rhel8/mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
       environment_setup: >-4
           yum -y module enable mariadb:{{ spec.version}} && \
@@ -33,6 +34,7 @@ specs:
       org: "rhel9"
       prod: "rhel9"
       img_name: "rhel9/mariadb-{{ spec.short }}"
+      full_img_name: "rhel9/mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"      
       com_redhat_component: "mariadb-{{ spec.short }}-container"
       environment_setup: >-4
@@ -45,6 +47,7 @@ specs:
       org: "rhel10"
       prod: "rhel10"
       img_name: "rhel10/mariadb-{{ spec.short }}"
+      full_img_name: "rhel10/mariadb-{{ spec.short }}"
       com_redhat_component: "mariadb-{{ spec.short }}-container"
       pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -84,7 +84,7 @@ specs:
       rhel_image_name: "rhel8/mariadb-103"
       s2i_example_name: "my-mariadb-rhel8"
       upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-103-to-mariadb-104"
-      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0."
+      upgrade_skip_note: "Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported; the only exception is upgrading from MariaDB 10.3 to 10.5."
 
     "10.5":
       version: "10.5"
@@ -92,7 +92,7 @@ specs:
       rhel_image_name: "rhel9/mariadb-105"
       s2i_example_name: "my-mariadb-rhel9"
       upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-4-to-mariadb-10-5"
-      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.5."
+      upgrade_skip_note: "Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported; the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.5."
 
     "10.11":
       version: "10.11"
@@ -100,7 +100,7 @@ specs:
       rhel_image_name: "rhel10/mariadb-1011"
       s2i_example_name: "my-mariadb-rhel10"
       upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-from-mariadb-10-6-to-mariadb-10-11"
-      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11."
+      upgrade_skip_note: "Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported; the only exception is upgrading from MariaDB 10.6 to MariaDB 10.11."
 
     "11.8":
       version: "11.8"
@@ -108,7 +108,7 @@ specs:
       rhel_image_name: "rhel10/mariadb-118"
       s2i_example_name: "my-mariadb-rhel10"
       upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0"
-      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 11.11."
+      upgrade_skip_note: "Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;"
 
 
 matrix:

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -24,7 +24,7 @@ specs:
       com_redhat_component: "mariadb-{{ spec.short }}-container"
       full_img_name: "rhel8/mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
-      environment_setup: >-4
+      environment_setup:
           yum -y module enable mariadb:{{ spec.version}} && \
 
     rhel9:
@@ -37,7 +37,7 @@ specs:
       full_img_name: "rhel9/mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"      
       com_redhat_component: "mariadb-{{ spec.short }}-container"
-      environment_setup: >-4
+      environment_setup:
           dnf -y module enable mariadb:{{ spec.version}} && \
 
     rhel10:
@@ -62,7 +62,7 @@ specs:
       full_img_name: "quay.io/sclorg/mariadb-{{ spec.short }}-c9s"
       com_redhat_component: "mariadb-{{ spec.short }}-{{ spec.prod }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
-      environment_setup: >-4
+      environment_setup:
           yum -y module enable mariadb:{{ spec.version }} && \
 
     c10s:

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -11,6 +11,7 @@ specs:
       prod: "fedora"
       img_name: "fedora/mariadb-{{ spec.short }}"
       full_img_name: "quay.io/fedora/mariadb-{{ spec.short }}"
+      com_redhat_component: "mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
 
     rhel8:
@@ -20,6 +21,7 @@ specs:
       org: "rhel8"
       prod: "rhel8"
       img_name: "rhel8/mariadb-{{ spec.short }}"
+      com_redhat_component: "mariadb-{{ spec.short }}-container"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
       environment_setup: >-4
           yum -y module enable mariadb:{{ spec.version}} && \
@@ -32,6 +34,7 @@ specs:
       prod: "rhel9"
       img_name: "rhel9/mariadb-{{ spec.short }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"      
+      com_redhat_component: "mariadb-{{ spec.short }}-container"
       environment_setup: >-4
           dnf -y module enable mariadb:{{ spec.version}} && \
 
@@ -42,6 +45,7 @@ specs:
       org: "rhel10"
       prod: "rhel10"
       img_name: "rhel10/mariadb-{{ spec.short }}"
+      com_redhat_component: "mariadb-{{ spec.short }}-container"
       pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
 
     c9s:
@@ -53,6 +57,7 @@ specs:
       prod: "c9s"
       img_name: "sclorg/mariadb-{{ spec.short }}-c9s"
       full_img_name: "quay.io/sclorg/mariadb-{{ spec.short }}-c9s"
+      com_redhat_component: "mariadb-{{ spec.short }}-{{ spec.prod }}"
       pkgs: "policycoreutils rsync tar gettext hostname groff-base"
       environment_setup: >-4
           yum -y module enable mariadb:{{ spec.version }} && \
@@ -66,6 +71,7 @@ specs:
       prod: "c10s"
       img_name: "sclorg/mariadb-{{ spec.short }}-c10s"
       full_img_name: "quay.io/sclorg/mariadb-{{ spec.short }}-c10s"
+      com_redhat_component: "mariadb-{{ spec.short }}-{{ spec.prod }}"
       pkgs: "policycoreutils rsync tar xz gettext hostname groff-base"
 
   version:
@@ -74,7 +80,7 @@ specs:
       short: "103"
       rhel_image_name: "rhel8/mariadb-103"
       s2i_example_name: "my-mariadb-rhel8"
-      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-102-to-mariadb-103/"
+      upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-103-to-mariadb-104"
       upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0."
 
     "10.5":
@@ -82,7 +88,7 @@ specs:
       short: "105"
       rhel_image_name: "rhel9/mariadb-105"
       s2i_example_name: "my-mariadb-rhel9"
-      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-105/"
+      upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-4-to-mariadb-10-5"
       upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.5."
 
     "10.11":
@@ -90,7 +96,7 @@ specs:
       short: "1011"
       rhel_image_name: "rhel10/mariadb-1011"
       s2i_example_name: "my-mariadb-rhel10"
-      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/"
+      upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-from-mariadb-10-6-to-mariadb-10-11"
       upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11."
 
     "11.8":
@@ -98,8 +104,8 @@ specs:
       short: "118"
       rhel_image_name: "rhel10/mariadb-118"
       s2i_example_name: "my-mariadb-rhel10"
-      upgrade_doc_url: "https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/"
-      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11."
+      upgrade_doc_url: "https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0"
+      upgrade_skip_note: "MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 11.11."
 
 
 matrix:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,11 +22,10 @@ ENV VERSION="${MYSQL_VERSION}" \
     ARCH=x86_64 \
     SUMMARY="MariaDB {{ spec.version }} SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
-    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
-    The mysqld server daemon accepts connections from clients and provides access to content from \
-    MariaDB databases on behalf of the clients."
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
 
-# Standalone ENV call so these values can be re-used in the other ENV calls
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
@@ -47,14 +46,14 @@ EXPOSE 3306
 {% if spec.version == "10.3" or (spec.version == "10.5" and spec.prod == "rhel8") or (spec.version in ["10.11", "11.8"] and spec.prod not in ["c10s", "rhel10"]) %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-{% elif spec.version == "10.5" and spec.prod == "c9s" %}
+    {% elif spec.version == "10.5" and spec.prod == "c9s" %}
 RUN dnf -y module disable mariadb && \
     INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-{% elif spec.version == "10.5" and spec.prod not in  ["c9s", "rhel8"] %}
+    {% elif spec.version == "10.5" and spec.prod not in  ["c9s", "rhel8"] %}
 RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-{% elif spec.version in ["10.11", "11.8"] and spec.prod in ["c10s", "rhel10"] %}
+    {% elif spec.version in ["10.11", "11.8"] and spec.prod in ["c10s", "rhel10"] %}
 RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}${MYSQL_VERSION}-server" && \
-{% endif %}
+    {% endif %}
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -56,7 +56,6 @@ RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
 RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}${MYSQL_VERSION}-server" && \
 {% endif %}
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -33,10 +33,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB {{ spec.version }}" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb{{ spec.short }},mariadb-{{ spec.short }}" \
-      com.redhat.component="{{ com_redhat_component }}" \
-      name="{{ spec.image_name }}" \
+      com.redhat.component="{{ spec.com_redhat_component }}" \
+      name="{{ spec.img_name }}" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.img_name }}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.full_img_name }}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -44,7 +44,7 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-{% if spec.version == "10.3" or (spec.version == "10.5" and spec.prod == "rhel8") or (spec.version in ["10.11", "11.8"] and spec.prod not in ["c10s", "rhel10"]) or %}
+{% if spec.version == "10.3" or (spec.version == "10.5" and spec.prod == "rhel8") or (spec.version in ["10.11", "11.8"] and spec.prod not in ["c10s", "rhel10"]) %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
 {% elif spec.version == "10.5" and spec.prod == "c9s" %}
@@ -54,13 +54,13 @@ RUN dnf -y module disable mariadb && \
 RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
 {% elif spec.version in ["10.11", "11.8"] and spec.prod in ["c10s", "rhel10"] %}
 RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}${MYSQL_VERSION}-server" && \
+{% endif %}
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
     dnf -y clean all --enablerepo='*' && \
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
-
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,135 @@
+FROM {{ spec.s2i_base }}{% if spec.s2i_base_tag %}:{{ spec.s2i_base_tag }}{% endif %}
+
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+# Standalone ENV call so these values can be re-used in the other ENV calls
+ENV MYSQL_VERSION={{ spec.version }} \
+    MYSQL_SHORT_VERSION={{ spec.short }}
+
+ENV VERSION="${MYSQL_VERSION}" \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mariadb \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB {{ spec.version }} SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+    image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+    The mysqld server daemon accepts connections from clients and provides access to content from \
+    MariaDB databases on behalf of the clients."
+
+# Standalone ENV call so these values can be re-used in the other ENV calls
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="MariaDB {{ spec.version }}" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mariadb,mariadb{{ spec.short }},mariadb-{{ spec.short }}" \
+{% if spec.org != "sclorg" %}
+      com.redhat.component="${NAME}-{{ spec.short }}-container" \
+      name="{{ spec.prod }}/${NAME}-{{ spec.short }}" \
+{% else %}
+      com.redhat.component="${NAME}-{{ spec.short }}-{{ spec.prod}}" \
+      name="sclorg/${NAME}-{{ spec.short }}-{{ spec.prod }}" \
+{% endif %}
+{% if spec.prod != "rhel10" or spec.version != "10.11" %}
+      version="1" \
+{% endif %}
+{% if config.os.id == "rhel" or spec.prod in ["c9s", "c10s"] %}
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+{% endif %}
+{% if spec.prod in ["rhel9", "rhel10"] %}
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.prod }}/${NAME}-{{ spec.short }}" \
+{% elif spec.prod in ["c9s", "c10s"] %}
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-{{ spec.short }}-{{ spec.prod }}" \
+{% endif %}
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+{% if spec.version == "10.3" %}
+RUN {{ spec.environment_setup }}
+    INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+{% elif spec.version == "10.5" %}
+{% if spec.prod == "c9s" %}
+RUN yum -y module disable mariadb && \
+    INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+{% elif spec.prod == "rhel8" %}
+RUN {{ spec.environment_setup }}
+    INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+{% else %}
+RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+{% endif %}
+{% elif spec.version == "10.11" %}
+{% if spec.prod in ["c10s", "rhel10"] %}
+RUN INSTALL_PKGS="{{ spec.pkgs }}" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+{% else %}
+RUN {{ spec.environment_setup }}
+    INSTALL_PKGS="{{ spec.pkgs }}" && \
+{% if spec.prod == "rhel9" %}
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
+{% else %}
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
+{% endif %}
+{% endif %}
+{% elif spec.version == "11.8" %}
+{% if spec.prod in ["c10s", "rhel10"] %}
+RUN INSTALL_PKGS="{{ spec.pkgs }}" && \
+    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+{% else %}
+RUN {{ spec.environment_setup }}
+    INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+{% endif %}
+{% endif %}
+    rpm -V ${INSTALL_PKGS} && \
+    /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
+{% if spec.prod in ["c10s", "rhel9", "rhel10"] %}
+    dnf -y clean all --enablerepo='*' && \
+{% else %}
+    yum -y clean all --enablerepo='*' && \
+{% endif %}
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+
+COPY {{ spec.version }}/root-common /
+COPY {{ spec.version }}/s2i-common/bin/ $STI_SCRIPTS_PATH
+COPY {{ spec.version }}/root /
+
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-mysqld $STI_SCRIPTS_PATH/run
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -33,24 +33,10 @@ LABEL summary="${SUMMARY}" \
       io.k8s.display-name="MariaDB {{ spec.version }}" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mariadb,mariadb{{ spec.short }},mariadb-{{ spec.short }}" \
-{% if spec.org != "sclorg" %}
-      com.redhat.component="${NAME}-{{ spec.short }}-container" \
-      name="{{ spec.prod }}/${NAME}-{{ spec.short }}" \
-{% else %}
-      com.redhat.component="${NAME}-{{ spec.short }}-{{ spec.prod}}" \
-      name="sclorg/${NAME}-{{ spec.short }}-{{ spec.prod }}" \
-{% endif %}
-{% if spec.prod != "rhel10" or spec.version != "10.11" %}
-      version="1" \
-{% endif %}
-{% if config.os.id == "rhel" or spec.prod in ["c9s", "c10s"] %}
+      com.redhat.component="{{ com_redhat_component }}" \
+      name="{{ spec.image_name }}" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
-{% endif %}
-{% if spec.prod in ["rhel9", "rhel10"] %}
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.prod }}/${NAME}-{{ spec.short }}" \
-{% elif spec.prod in ["c9s", "c10s"] %}
-      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/sclorg/${NAME}-{{ spec.short }}-{{ spec.prod }}" \
-{% endif %}
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.img_name }}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 3306
@@ -58,53 +44,20 @@ EXPOSE 3306
 # This image must forever use UID 27 for mysql user so our volumes are
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
-{% if spec.version == "10.3" %}
+{% if spec.version == "10.3" or (spec.version == "10.5" and spec.prod == "rhel8") or (spec.version in ["10.11", "11.8"] and spec.prod not in ["c10s", "rhel10"]) or %}
 RUN {{ spec.environment_setup }}
     INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-{% elif spec.version == "10.5" %}
-{% if spec.prod == "c9s" %}
-RUN yum -y module disable mariadb && \
+{% elif spec.version == "10.5" and spec.prod == "c9s" %}
+RUN dnf -y module disable mariadb && \
     INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-{% elif spec.prod == "rhel8" %}
-RUN {{ spec.environment_setup }}
-    INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-{% else %}
+{% elif spec.version == "10.5" and spec.prod not in  ["c9s", "rhel8"] %}
 RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
+{% elif spec.version in ["10.11", "11.8"] and spec.prod in ["c10s", "rhel10"] %}
+RUN INSTALL_PKGS="{{ spec.pkgs }} ${NAME}${MYSQL_VERSION}-server" && \
     dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-{% endif %}
-{% elif spec.version == "10.11" %}
-{% if spec.prod in ["c10s", "rhel10"] %}
-RUN INSTALL_PKGS="{{ spec.pkgs }}" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
-{% else %}
-RUN {{ spec.environment_setup }}
-    INSTALL_PKGS="{{ spec.pkgs }}" && \
-{% if spec.prod == "rhel9" %}
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
-{% else %}
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}-server && \
-{% endif %}
-{% endif %}
-{% elif spec.version == "11.8" %}
-{% if spec.prod in ["c10s", "rhel10"] %}
-RUN INSTALL_PKGS="{{ spec.pkgs }}" && \
-    dnf install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
-{% else %}
-RUN {{ spec.environment_setup }}
-    INSTALL_PKGS="{{ spec.pkgs }} ${NAME}-server" && \
-    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
-{% endif %}
-{% endif %}
     rpm -V ${INSTALL_PKGS} && \
     /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
-{% if spec.prod in ["c10s", "rhel9", "rhel10"] %}
     dnf -y clean all --enablerepo='*' && \
-{% else %}
-    yum -y clean all --enablerepo='*' && \
-{% endif %}
     mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -1,0 +1,82 @@
+FROM {{ spec.s2i_base }}:{{ spec.s2i_base_tag }}
+
+# MariaDB image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MariaDB
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+# Standalone ENV call so these values can be re-used in the other ENV calls
+ENV MYSQL_VERSION={{ spec.version }} \
+    MYSQL_SHORT_VERSION={{ spec.short }}{% if spec.version == "10.11" %}  {% endif %}
+
+
+ENV VERSION="${MYSQL_VERSION}" \
+    APP_DATA=/opt/app-root/src \
+    HOME=/var/lib/mysql \
+    NAME=mariadb \
+    ARCH=x86_64 \
+    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
+image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
+The mysqld server daemon accepts connections from clients and provides access to content from \
+MariaDB databases on behalf of the clients."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
+      com.redhat.component="${NAME}" \
+      name="fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
+      version="${MYSQL_VERSION}" \
+      usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 3306
+
+# This image must forever use UID 27 for mysql user so our volumes are safe in the future. This should *never* change.
+# Instead of relying on the DB server package, we will do the setup ourselves before any package is installed
+RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
+    /usr/sbin/useradd -M -N -g mysql -o -r -d ${HOME} -s /sbin/nologin -c "MySQL Server" -u 27 mysql && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)" && \
+    INSTALL_PKGS="policycoreutils rsync tar gettext hostname groff-base" && \
+    dnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=False ${INSTALL_PKGS} ${NAME}${MYSQL_VERSION}-server && \
+    /usr/libexec/mysqld -V | grep -qe "${MYSQL_VERSION}\." && echo "Found VERSION ${MYSQL_VERSION}" && \
+    dnf -y clean all --enablerepo='*' && \
+    mkdir -p ${HOME}/data && chown -R mysql:root ${HOME} && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
+    MYSQL_PREFIX=/usr
+{% if spec.version == "11.8" %}
+
+{% endif %}
+
+COPY ${MYSQL_VERSION}/root-common /
+COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
+COPY ${MYSQL_VERSION}/root /
+
+# Hard links are not supported in Testing Farm approach during sync to guest
+# operation system. Therefore tests are failing on error
+# /usr/libexec/s2i/run no such file or directory
+RUN ln -s /usr/bin/run-mysqld ${STI_SCRIPTS_PATH}/run
+
+# this is needed due to issues with squash
+# when this directory gets rm'd by the container-setup
+# script.
+# Also reset permissions of filesystem to default values
+RUN rm -rf /etc/my.cnf.d/* && \
+    /usr/libexec/container-setup && \
+    rpm-file-permissions
+
+USER 27
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-mysqld"]

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -20,7 +20,7 @@ ENV VERSION="${MYSQL_VERSION}" \
     HOME=/var/lib/mysql \
     NAME=mariadb \
     ARCH=x86_64 \
-    SUMMARY="MariaDB ${MYSQL_VERSION} SQL database server" \
+    SUMMARY="MariaDB {{ spec.version }} SQL database server" \
     DESCRIPTION="MariaDB is a multi-user, multi-threaded SQL database server. The container \
 image provides a containerized packaging of the MariaDB mysqld daemon and client application. \
 The mysqld server daemon accepts connections from clients and provides access to content from \
@@ -29,12 +29,11 @@ MariaDB databases on behalf of the clients."
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="MariaDB ${MYSQL_VERSION}" \
+      io.k8s.display-name="MariaDB {{ spec.version }}" \
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,${NAME},${NAME}${MYSQL_SHORT_VERSION},${NAME}-${MYSQL_SHORT_VERSION}" \
       com.redhat.component="${NAME}" \
       name="fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
-      version="${MYSQL_VERSION}" \
       usage="podman run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 quay.io/fedora/${NAME}-${MYSQL_SHORT_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -56,9 +55,9 @@ RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
 
-COPY ${MYSQL_VERSION}/root-common /
-COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
-COPY ${MYSQL_VERSION}/root /
+COPY {{ spec.version }}/root-common /
+COPY {{ spec.version }}/s2i-common/bin/ ${STI_SCRIPTS_PATH}
+COPY {{ spec.version }}/root /
 
 # Hard links are not supported in Testing Farm approach during sync to guest
 # operation system. Therefore tests are failing on error

--- a/src/Dockerfile.fedora
+++ b/src/Dockerfile.fedora
@@ -12,7 +12,7 @@ FROM {{ spec.s2i_base }}:{{ spec.s2i_base_tag }}
 
 # Standalone ENV call so these values can be re-used in the other ENV calls
 ENV MYSQL_VERSION={{ spec.version }} \
-    MYSQL_SHORT_VERSION={{ spec.short }}{% if spec.version == "10.11" %}  {% endif %}
+    MYSQL_SHORT_VERSION={{ spec.short }}
 
 
 ENV VERSION="${MYSQL_VERSION}" \
@@ -55,9 +55,6 @@ RUN /usr/sbin/groupadd -g 27 -o -r mysql && \
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/mysql \
     MYSQL_PREFIX=/usr
-{% if spec.version == "11.8" %}
-
-{% endif %}
 
 COPY ${MYSQL_VERSION}/root-common /
 COPY ${MYSQL_VERSION}/s2i-common/bin/ ${STI_SCRIPTS_PATH}

--- a/src/root/usr/share/container-scripts/mysql/README.md
+++ b/src/root/usr/share/container-scripts/mysql/README.md
@@ -1,0 +1,762 @@
+{% if spec.version == "11.8" -%}
+MariaDB 11.8 SQL Database Server Container image
+=============================================
+
+This container image includes MariaDB 11.8 SQL database server for OpenShift and general usage.
+
+<!---Users can choose between RHEL, CentOS and Fedora based images.
+The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
+and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).-->
+
+Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
+The resulting image can be run using [podman](https://github.com/containers/libpod).
+
+Note: while the examples in this README call `podman`, you can replace any such calls by `docker` with the same arguments
+
+Description
+-----------
+
+This container image provides a containerized packaging of the MariaDB mysqld daemon
+and client application. The mysqld server daemon accepts connections from clients
+and provides access to content from MySQL databases on behalf of the clients.
+You can find more information on the MariaDB project from the project Web site
+(https://mariadb.org/).
+
+
+Usage
+-----
+<!--- TODO: change back to rhel10 when the image comes out -->
+For this, we will assume that you are using the MariaDB 11.8 container image from the
+Quay.io registry called `fedora/mariadb-118`.
+If you want to set only the mandatory environment variables and not store
+the database in a host directory, execute the following command:
+
+```
+$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 fedora/mariadb-118
+```
+
+This will create a container named `mariadb_database` running MySQL with database
+`db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
+to the host. If you want your database to be persistent across container executions,
+also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
+data directory.
+
+If the database directory is not initialized, the entrypoint script will first
+run [`mysql_install_db`](https://dev.mysql.com/doc/refman/5.6/en/mysql-install-db.html)
+and setup necessary database users and passwords. After the database is initialized,
+or if it was already present, `mysqld` is executed and will run as PID 1. You can
+ stop the detached container by running `podman stop mariadb_database`.
+
+
+Environment variables and volumes
+---------------------------------
+The image recognizes the following environment variables that you can set during
+initialization by passing `-e VAR=VALUE` to the Docker run command.
+
+**`MYSQL_USER`**  
+       User name for MySQL account to be created
+
+**`MYSQL_PASSWORD`**  
+       Password for the user account
+
+**`MYSQL_DATABASE`**  
+       Database name
+
+**`MYSQL_ROOT_PASSWORD`**  
+       Password for the root user (optional)
+
+**`MYSQL_CHARSET`**  
+       Default character set (optional)
+
+**`MYSQL_COLLATION`**  
+       Default collation (optional)
+
+
+The following environment variables influence the MySQL configuration file. They are all optional.
+
+**`MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)`**  
+       Sets how the table names are stored and compared
+
+**`MYSQL_MAX_CONNECTIONS (default: 151)`**  
+       The maximum permitted number of simultaneous client connections
+
+**`MYSQL_MAX_ALLOWED_PACKET (default: 200M)`**  
+       The maximum size of one packet or any generated/intermediate string
+
+**`MYSQL_FT_MIN_WORD_LEN (default: 4)`**  
+       The minimum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_FT_MAX_WORD_LEN (default: 20)`**  
+       The maximum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_AIO (default: 1)`**  
+       Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529
+
+**`MYSQL_TABLE_OPEN_CACHE (default: 400)`**  
+       The number of open tables for all threads
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)`**  
+       The size of the buffer used for index blocks
+
+**`MYSQL_SORT_BUFFER_SIZE (default: 256K)`**  
+       The size of the buffer used for sorting
+
+**`MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)`**  
+       The size of the buffer used for a sequential scan
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)`**  
+       The size of the buffer pool where InnoDB caches table and index data
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available memory)`**  
+       The size of each log file in a log group
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)`**  
+       The size of the buffer that InnoDB uses to write to the log files on disk
+
+**`MYSQL_DEFAULTS_FILE (default: /etc/my.cnf)`**  
+       Point to an alternative configuration file
+
+**`MYSQL_BINLOG_FORMAT (default: statement)`**  
+       Set sets the binlog format, supported values are `row` and `statement`
+
+**`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
+       To enable query logging set this to `1`
+
+
+You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
+
+**`/var/lib/mysql/data`**  
+       MySQL data directory
+
+
+**Notice: When mouting a directory from the host into the container, ensure that the mounted
+directory has the appropriate permissions and that the owner and group of the directory
+matches the user UID or name which is running inside the container.**
+
+
+MariaDB auto-tuning
+-------------------
+
+When the MySQL image is run with the `--memory` parameter set and you didn't
+specify value for some parameters, their values will be automatically
+calculated based on the available memory.
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 10%)`**  
+       `key_buffer_size`
+
+**`MYSQL_READ_BUFFER_SIZE (default: 5%)`**  
+       `read_buffer_size`
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 50%)`**  
+       `innodb_buffer_pool_size`
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 15%)`**  
+       `innodb_log_file_size`
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 15%)`**  
+       `innodb_log_buffer_size`
+
+
+
+MySQL root user
+---------------------------------
+The root user has no password set by default, only allowing local connections.
+You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
+will allow you to login to the root account remotely. Local connections will
+still not require a password.
+
+To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
+the container.
+
+
+Changing passwords
+------------------
+
+Since passwords are part of the image configuration, the only supported method
+to change passwords for the database user (`MYSQL_USER`) and root user is by
+changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
+respectively.
+
+Changing database passwords through SQL statements or any way other than through
+the environment variables aforementioned will cause a mismatch between the
+values stored in the variables and the actual passwords. Whenever a database
+container starts it will reset the passwords to the values stored in the
+environment variables.
+
+
+Default my.cnf file
+-------------------
+With environment variables we are able to customize a lot of different parameters
+or configurations for the mysql bootstrap configurations. If you'd prefer to use
+your own configuration file, you can override the `MYSQL_DEFAULTS_FILE` env
+variable with the full path of the file you wish to use. For example, the default
+location is `/etc/my.cnf` but you can change it to `/etc/mysql/my.cnf` by setting
+ `MYSQL_DEFAULTS_FILE=/etc/mysql/my.cnf`
+
+<!--- TODO: put back when the rhel/centos images are released
+Extending image
+---------------
+This image can be extended in Openshift using the `Source` build strategy or via the standalone
+[source-to-image](https://docs.openshift.com/container-platform/4.14/openshift_images/create-images.html#images-create-s2i_create-images) application (where available).
+For this, we will assume that you are using the `rhel10/mariadb-118` image,
+available via `mariadb:11.8` imagestream tag in Openshift.
+
+
+For example, to build a customized MariaDB database image `my-mariadb-rhel10`
+with a configuration from `https://github.com/sclorg/mariadb-container/tree/master/examples/extend-image` run:
+
+```
+$ oc new-app mariadb:11.8~https://github.com/sclorg/mariadb-container.git \
+    --name my-mariadb-rhel10 \
+    --context-dir=examples/extend-image \
+    --env MYSQL_OPERATIONS_USER=opuser \
+    --env MYSQL_OPERATIONS_PASSWORD=oppass \
+    --env MYSQL_DATABASE=opdb \
+    --env MYSQL_USER=user \
+    --env MYSQL_PASSWORD=pass
+```
+
+or via s2i:
+
+```
+$ s2i build --context-dir=examples/extend-image https://github.com/sclorg/mariadb-container.git rhel10/mariadb-118 my-mariadb-rhel10
+```
+
+The directory passed to Openshift can contain these directories:
+
+`mysql-cfg/`
+    When starting the container, files from this directory will be used as
+    a configuration for the `mysqld` daemon.
+    `envsubst` command is run on this file to still allow customization of
+    the image using environmental variables
+
+`mysql-pre-init/`
+    Shell scripts (`*.sh`) available in this directory are sourced before
+    `mysqld` daemon is started.
+
+`mysql-init/`
+    Shell scripts (`*.sh`) available in this directory are sourced when
+    `mysqld` daemon is started locally. In this phase, use `${mysql_flags}`
+    to connect to the locally running daemon, for example `mysql $mysql_flags < dump.sql`
+
+Variables that can be used in the scripts provided to s2i:
+
+`$mysql_flags`
+    arguments for the `mysql` tool that will connect to the locally running `mysqld` during initialization
+
+`$MYSQL_RUNNING_AS_MASTER`
+    variable defined when the container is run with `run-mysqld-master` command
+
+`$MYSQL_RUNNING_AS_SLAVE`
+    variable defined when the container is run with `run-mysqld-slave` command
+
+`$MYSQL_DATADIR_FIRST_INIT`
+    variable defined when the container was initialized from the empty data dir
+
+During the s2i build all provided files are copied into `/opt/app-root/src`
+directory into the resulting image. If some configuration files are present
+in the destination directory, files with the same name are overwritten.
+Also only one file with the same name can be used for customization and user
+provided files are preferred over default files in
+`/usr/share/container-scripts/mysql/`- so it is possible to overwrite them.
+
+Same configuration directory structure can be used to customize the image
+every time the image is started using `podman run`. The directory has to be
+mounted into `/opt/app-root/src/` in the image
+(`-v ./image-configuration/:/opt/app-root/src/`).
+This overwrites customization built into the image.
+-->
+
+Securing the connection with SSL
+--------------------------------
+In order to secure the connection with SSL, use the extending feature described
+above. In particular, put the SSL certificates into a separate directory:
+
+    sslapp/mysql-certs/server-cert-selfsigned.pem
+    sslapp/mysql-certs/server-key.pem
+
+And then put a separate configuration file into mysql-cfg:
+
+    $> cat sslapp/mysql-cfg/ssl.cnf
+    [mysqld]
+    ssl-key=${APP_DATA}/mysql-certs/server-key.pem
+    ssl-cert=${APP_DATA}/mysql-certs/server-cert-selfsigned.pem
+
+Such a directory `sslapp` can then be mounted into the container with -v,
+or a new container image can be built using s2i.
+
+
+Upgrading and data directory version checking
+---------------------------------------------
+MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
+For version changes in Z part, the server's binary data format stays compatible and thus no
+special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
+steps as described at
+https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/
+
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
+the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+
+**Important**: Upgrading to a new version is always risky and users are expected to make a full
+back-up of all data before.
+
+A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
+load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.
+
+Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
+and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
+faster for large data directory, but only possible if upgrading from the very previous version,
+so skipping versions is not supported.
+
+This container detects whether the data needs to be upgraded using `mysql_upgrade` and
+we can control it by setting `MYSQL_DATADIR_ACTION` variable, which can have one or more of the following values:
+
+ * `upgrade-warn` -- If the data version can be determined and the data come from a different version
+   of the daemon, a warning is printed but the container starts. This is the default value.
+   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
+   the version file is created if not exist, but no `mysql_upgrade` will be called.
+   However, this automatic creation will be removed after few months, since the version should be
+   created on most deployments at that point.
+ * `upgrade-auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+   daemon is running, but only if the data version can be determined and the data come
+   with the very previous version. A warning is printed if the data come from even older
+   or newer version. This value effectively enables automatic upgrades,
+   but it is always risky and users should still back-up all the data before starting the newer container.
+   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
+   from the back-up.
+ * `upgrade-force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+   daemon is running, no matter what version of the daemon the data come from.
+   This is also the way to create the missing version file `mysql_upgrade_info` if not present
+   in the root of the data directory; this file holds information about the version of the data.
+
+There are also some other actions that you may want to run at the beginning of the container start,
+when the local daemon is running, no matter what version of the data is detected:
+
+ * `optimize` -- runs `mysqlcheck --optimize`. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze`. It analyzes all the tables.
+ * `disable` -- nothing is done regarding data directory version.
+
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_DATADIR_ACTION="optimize,analyze"`.
+
+
+Changing the replication binlog_format
+--------------------------------------
+Some applications may wish to use `row` binlog_formats (for example, those built
+  with change-data-capture in mind). The default replication/binlog format is
+  `statement` but to change it you can set the `MYSQL_BINLOG_FORMAT` environment
+  variable. For example `MYSQL_BINLOG_FORMAT=row`. Now when you run the database
+  with `master` replication turned on (ie, set the Docker/container `cmd` to be
+`run-mysqld-master`) the binlog will emit the actual data for the rows that change
+as opposed to the statements (ie, DML like insert...) that caused the change.
+
+
+Troubleshooting
+---------------
+The mysqld deamon in the container logs to the standard output, so the log is available in the container log. The log can be examined by running:
+
+    podman logs <container>
+
+
+See also
+--------
+Dockerfile and other sources for this container image are available on
+https://github.com/sclorg/mariadb-container.
+In that repository,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
+the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
+and the Dockerfile for Fedora is called Dockerfile.fedora.
+{% else -%}
+{% if spec.version == "10.3" -%}
+MariaDB {{ spec.version }} SQL Database Server Docker image
+{% elif spec.version == "10.5" -%}
+MariaDB {{ spec.version }} SQL Database Server Docker image
+{% else -%}
+MariaDB {{ spec.version }} SQL Database Server Container image
+{% endif -%}
+=============================================
+
+This container image includes MariaDB {{ spec.version }} SQL database server for OpenShift and general usage.
+{% if spec.version == "10.3" -%}
+The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+{% elif spec.version == "10.5" -%}
+Users can choose between RHEL and CentOS Stream based images.
+The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+and the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg).
+{% else -%}
+Users can choose between RHEL, CentOS Stream and Fedora based images.
+The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
+the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
+and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
+{% endif -%}
+The resulting image can be run using [podman](https://github.com/containers/libpod).
+
+Note: while the examples in this README call `podman`, you can replace any such calls by `docker` with the same arguments
+
+Description
+-----------
+
+This container image provides a containerized packaging of the MariaDB mysqld daemon
+and client application. The mysqld server daemon accepts connections from clients
+and provides access to content from MySQL databases on behalf of the clients.
+You can find more information on the MariaDB project from the project Web site
+(https://mariadb.org/).
+
+
+Usage
+-----
+
+For this, we will assume that you are using the MariaDB {{ spec.version }} container image from the
+Red Hat Container Catalog called `{{ spec.rhel_image_name }}`.
+If you want to set only the mandatory environment variables and not store
+the database in a host directory, execute the following command:
+
+```
+$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.rhel_image_name }}
+```
+
+This will create a container named `mariadb_database` running MySQL with database
+`db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
+to the host. If you want your database to be persistent across container executions,
+also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
+data directory.
+
+If the database directory is not initialized, the entrypoint script will first
+run [`mysql_install_db`](https://dev.mysql.com/doc/refman/5.6/en/mysql-install-db.html)
+and setup necessary database users and passwords. After the database is initialized,
+or if it was already present, `mysqld` is executed and will run as PID 1. You can
+ stop the detached container by running `podman stop mariadb_database`.
+
+
+Environment variables and volumes
+---------------------------------
+
+The image recognizes the following environment variables that you can set during
+initialization by passing `-e VAR=VALUE` to the Docker run command.
+
+**`MYSQL_USER`**  
+       User name for MySQL account to be created
+
+**`MYSQL_PASSWORD`**  
+       Password for the user account
+
+**`MYSQL_DATABASE`**  
+       Database name
+
+**`MYSQL_ROOT_PASSWORD`**  
+       Password for the root user (optional)
+
+**`MYSQL_CHARSET`**  
+       Default character set (optional)
+
+**`MYSQL_COLLATION`**  
+       Default collation (optional)
+
+
+The following environment variables influence the MySQL configuration file. They are all optional.
+
+**`MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)`**  
+       Sets how the table names are stored and compared
+
+**`MYSQL_MAX_CONNECTIONS (default: 151)`**  
+       The maximum permitted number of simultaneous client connections
+
+**`MYSQL_MAX_ALLOWED_PACKET (default: 200M)`**  
+       The maximum size of one packet or any generated/intermediate string
+
+**`MYSQL_FT_MIN_WORD_LEN (default: 4)`**  
+       The minimum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_FT_MAX_WORD_LEN (default: 20)`**  
+       The maximum length of the word to be included in a FULLTEXT index
+
+**`MYSQL_AIO (default: 1)`**  
+       Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529
+
+**`MYSQL_TABLE_OPEN_CACHE (default: 400)`**  
+       The number of open tables for all threads
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)`**  
+       The size of the buffer used for index blocks
+
+**`MYSQL_SORT_BUFFER_SIZE (default: 256K)`**  
+       The size of the buffer used for sorting
+
+**`MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)`**  
+       The size of the buffer used for a sequential scan
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)`**  
+       The size of the buffer pool where InnoDB caches table and index data
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available memory)`**  
+       The size of each log file in a log group
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)`**  
+       The size of the buffer that InnoDB uses to write to the log files on disk
+
+**`MYSQL_DEFAULTS_FILE (default: /etc/my.cnf)`**  
+       Point to an alternative configuration file
+
+**`MYSQL_BINLOG_FORMAT (default: statement)`**  
+       Set sets the binlog format, supported values are `row` and `statement`
+
+**`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
+       To enable query logging set this to `1`
+
+
+You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
+
+**`/var/lib/mysql/data`**  
+       MySQL data directory
+
+
+**Notice: When mouting a directory from the host into the container, ensure that the mounted
+directory has the appropriate permissions and that the owner and group of the directory
+matches the user UID or name which is running inside the container.**
+
+
+MariaDB auto-tuning
+-------------------
+
+When the MySQL image is run with the `--memory` parameter set and you didn't
+specify value for some parameters, their values will be automatically
+calculated based on the available memory.
+
+**`MYSQL_KEY_BUFFER_SIZE (default: 10%)`**  
+       `key_buffer_size`
+
+**`MYSQL_READ_BUFFER_SIZE (default: 5%)`**  
+       `read_buffer_size`
+
+**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 50%)`**  
+       `innodb_buffer_pool_size`
+
+**`MYSQL_INNODB_LOG_FILE_SIZE (default: 15%)`**  
+       `innodb_log_file_size`
+
+**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 15%)`**  
+       `innodb_log_buffer_size`
+
+
+
+MySQL root user
+---------------------------------
+The root user has no password set by default, only allowing local connections.
+You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
+will allow you to login to the root account remotely. Local connections will
+still not require a password.
+
+To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
+the container.
+
+
+Changing passwords
+------------------
+
+Since passwords are part of the image configuration, the only supported method
+to change passwords for the database user (`MYSQL_USER`) and root user is by
+changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
+respectively.
+
+Changing database passwords through SQL statements or any way other than through
+the environment variables aforementioned will cause a mismatch between the
+values stored in the variables and the actual passwords. Whenever a database
+container starts it will reset the passwords to the values stored in the
+environment variables.
+
+
+Default my.cnf file
+-------------------
+With environment variables we are able to customize a lot of different parameters
+or configurations for the mysql bootstrap configurations. If you'd prefer to use
+your own configuration file, you can override the `MYSQL_DEFAULTS_FILE` env
+variable with the full path of the file you wish to use. For example, the default
+location is `/etc/my.cnf` but you can change it to `/etc/mysql/my.cnf` by setting
+ `MYSQL_DEFAULTS_FILE=/etc/mysql/my.cnf`
+
+
+Extending image
+---------------
+This image can be extended in Openshift using the `Source` build strategy or via the standalone
+[source-to-image](https://docs.openshift.com/container-platform/4.14/openshift_images/create-images.html#images-create-s2i_create-images) application (where available).
+For this, we will assume that you are using the `{{ spec.rhel_image_name }}` image,
+available via `mariadb:{{ spec.version }}` imagestream tag in Openshift.
+
+
+For example, to build a customized MariaDB database image `{{ spec.s2i_example_name }}`
+with a configuration from `https://github.com/sclorg/mariadb-container/tree/master/examples/extend-image` run:
+
+```
+$ oc new-app mariadb:{{ spec.version }}~https://github.com/sclorg/mariadb-container.git \
+    --name {{ spec.s2i_example_name }} \
+    --context-dir=examples/extend-image \
+    --env MYSQL_OPERATIONS_USER=opuser \
+    --env MYSQL_OPERATIONS_PASSWORD=oppass \
+    --env MYSQL_DATABASE=opdb \
+    --env MYSQL_USER=user \
+    --env MYSQL_PASSWORD=pass
+```
+
+or via s2i:
+
+```
+$ s2i build --context-dir=examples/extend-image https://github.com/sclorg/mariadb-container.git {{ spec.rhel_image_name }} {{ spec.s2i_example_name }}
+```
+
+The directory passed to Openshift can contain these directories:
+
+`mysql-cfg/`
+    When starting the container, files from this directory will be used as
+    a configuration for the `mysqld` daemon.
+    `envsubst` command is run on this file to still allow customization of
+    the image using environmental variables
+
+`mysql-pre-init/`
+    Shell scripts (`*.sh`) available in this directory are sourced before
+    `mysqld` daemon is started.
+
+`mysql-init/`
+    Shell scripts (`*.sh`) available in this directory are sourced when
+    `mysqld` daemon is started locally. In this phase, use `${mysql_flags}`
+    to connect to the locally running daemon, for example `mysql $mysql_flags < dump.sql`
+
+Variables that can be used in the scripts provided to s2i:
+
+`$mysql_flags`
+    arguments for the `mysql` tool that will connect to the locally running `mysqld` during initialization
+
+`$MYSQL_RUNNING_AS_MASTER`
+    variable defined when the container is run with `run-mysqld-master` command
+
+`$MYSQL_RUNNING_AS_SLAVE`
+    variable defined when the container is run with `run-mysqld-slave` command
+
+`$MYSQL_DATADIR_FIRST_INIT`
+    variable defined when the container was initialized from the empty data dir
+
+During the s2i build all provided files are copied into `/opt/app-root/src`
+directory into the resulting image. If some configuration files are present
+in the destination directory, files with the same name are overwritten.
+Also only one file with the same name can be used for customization and user
+provided files are preferred over default files in
+`/usr/share/container-scripts/mysql/`- so it is possible to overwrite them.
+
+Same configuration directory structure can be used to customize the image
+every time the image is started using `podman run`. The directory has to be
+mounted into `/opt/app-root/src/` in the image
+(`-v ./image-configuration/:/opt/app-root/src/`).
+This overwrites customization built into the image.
+
+
+Securing the connection with SSL
+--------------------------------
+In order to secure the connection with SSL, use the extending feature described
+above. In particular, put the SSL certificates into a separate directory:
+
+    sslapp/mysql-certs/server-cert-selfsigned.pem
+    sslapp/mysql-certs/server-key.pem
+
+And then put a separate configuration file into mysql-cfg:
+
+    $> cat sslapp/mysql-cfg/ssl.cnf
+    [mysqld]
+    ssl-key=${APP_DATA}/mysql-certs/server-key.pem
+    ssl-cert=${APP_DATA}/mysql-certs/server-cert-selfsigned.pem
+
+Such a directory `sslapp` can then be mounted into the container with -v,
+or a new container image can be built using s2i.
+
+
+Upgrading and data directory version checking
+---------------------------------------------
+
+MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
+For version changes in Z part, the server's binary data format stays compatible and thus no
+special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
+steps as described at
+{{ spec.upgrade_doc_url }}
+
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
+the only exception is ugrading from {{ spec.upgrade_skip_note }}
+
+**Important**: Upgrading to a new version is always risky and users are expected to make a full
+back-up of all data before.
+
+A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
+load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.
+
+Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
+and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
+faster for large data directory, but only possible if upgrading from the very previous version,
+so skipping versions is not supported.
+
+This container detects whether the data needs to be upgraded using `mysql_upgrade` and
+we can control it by setting `MYSQL_DATADIR_ACTION` variable, which can have one or more of the following values:
+
+ * `upgrade-warn` -- If the data version can be determined and the data come from a different version
+   of the daemon, a warning is printed but the container starts. This is the default value.
+   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
+   the version file is created if not exist, but no `mysql_upgrade` will be called.
+   However, this automatic creation will be removed after few months, since the version should be
+   created on most deployments at that point.
+ * `upgrade-auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
+   daemon is running, but only if the data version can be determined and the data come
+   with the very previous version. A warning is printed if the data come from even older
+   or newer version. This value effectively enables automatic upgrades,
+   but it is always risky and users should still back-up all the data before starting the newer container.
+   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
+   from the back-up.
+ * `upgrade-force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
+   daemon is running, no matter what version of the daemon the data come from.
+   This is also the way to create the missing version file `mysql_upgrade_info` if not present
+   in the root of the data directory; this file holds information about the version of the data.
+
+There are also some other actions that you may want to run at the beginning of the container start,
+when the local daemon is running, no matter what version of the data is detected:
+
+ * `optimize` -- runs `mysqlcheck --optimize`. It optimizes all the tables.
+ * `analyze` -- runs `mysqlcheck --analyze`. It analyzes all the tables.
+ * `disable` -- nothing is done regarding data directory version.
+
+Multiple values are separated by comma and run in-order, e.g. `MYSQL_DATADIR_ACTION="optimize,analyze"`.
+
+
+Changing the replication binlog_format
+--------------------------------------
+Some applications may wish to use `row` binlog_formats (for example, those built
+  with change-data-capture in mind). The default replication/binlog format is
+  `statement` but to change it you can set the `MYSQL_BINLOG_FORMAT` environment
+  variable. For example `MYSQL_BINLOG_FORMAT=row`. Now when you run the database
+  with `master` replication turned on (ie, set the Docker/container `cmd` to be
+`run-mysqld-master`) the binlog will emit the actual data for the rows that change
+as opposed to the statements (ie, DML like insert...) that caused the change.
+
+
+Troubleshooting
+---------------
+The mysqld deamon in the container logs to the standard output, so the log is available in the container log. The log can be examined by running:
+
+    podman logs <container>
+
+
+See also
+--------
+Dockerfile and other sources for this container image are available on
+https://github.com/sclorg/mariadb-container.
+{% if spec.version == "10.3" -%}
+In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8.
+{% elif spec.version == "10.5" -%}
+In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9
+and the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s.
+{% else -%}
+In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9,
+the Dockerfile for RHEL10 is called Dockerfile.rhel10,
+the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
+the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
+and the Dockerfile for Fedora is called Dockerfile.fedora.
+{% endif -%}
+{% endif -%}

--- a/src/root/usr/share/container-scripts/mysql/README.md
+++ b/src/root/usr/share/container-scripts/mysql/README.md
@@ -25,9 +25,9 @@ You can find more information on the MariaDB project from the project Web site
 
 Usage
 -----
-<!--- TODO: change back to rhel10 when the image comes out -->
+
 For this, we will assume that you are using the MariaDB {{ spec.version }} container image from the
-Quay.io registry called `{{ spec.image_name }}`.
+Red Hat Container Catalog called `{{ spec.rhel_image_name }}`.
 If you want to set only the mandatory environment variables and not store
 the database in a host directory, execute the following command:
 
@@ -50,6 +50,7 @@ or if it was already present, `mysqld` is executed and will run as PID 1. You ca
 
 Environment variables and volumes
 ---------------------------------
+
 The image recognizes the following environment variables that you can set during
 initialization by passing `-e VAR=VALUE` to the Docker run command.
 
@@ -193,6 +194,7 @@ variable with the full path of the file you wish to use. For example, the defaul
 location is `/etc/my.cnf` but you can change it to `/etc/mysql/my.cnf` by setting
  `MYSQL_DEFAULTS_FILE=/etc/mysql/my.cnf`
 
+
 Extending image
 ---------------
 This image can be extended in Openshift using the `Source` build strategy or via the standalone
@@ -264,6 +266,7 @@ every time the image is started using `podman run`. The directory has to be
 mounted into `/opt/app-root/src/` in the image
 (`-v ./image-configuration/:/opt/app-root/src/`).
 This overwrites customization built into the image.
+
 
 Securing the connection with SSL
 --------------------------------
@@ -359,7 +362,7 @@ See also
 --------
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/mariadb-container.
-In that repository,
+In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
 the Dockerfile for RHEL9 is called Dockerfile.rhel9,
 the Dockerfile for RHEL10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,

--- a/src/root/usr/share/container-scripts/mysql/README.md
+++ b/src/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,7 @@ steps as described at
 {{ spec.upgrade_doc_url }}
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/src/root/usr/share/container-scripts/mysql/README.md
+++ b/src/root/usr/share/container-scripts/mysql/README.md
@@ -295,8 +295,7 @@ special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider do
 steps as described at
 {{ spec.upgrade_doc_url }}
 
-Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is upgrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
+{{ spec.upgrade_skip_note }}
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/src/root/usr/share/container-scripts/mysql/README.md
+++ b/src/root/usr/share/container-scripts/mysql/README.md
@@ -1,8 +1,7 @@
-{% if spec.version == "11.8" -%}
-MariaDB 11.8 SQL Database Server Container image
+MariaDB {{ spec.version }} SQL Database Server Container image
 =============================================
 
-This container image includes MariaDB 11.8 SQL database server for OpenShift and general usage.
+This container image includes MariaDB {{ spec.version }} SQL database server for OpenShift and general usage.
 
 <!---Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
@@ -27,13 +26,13 @@ You can find more information on the MariaDB project from the project Web site
 Usage
 -----
 <!--- TODO: change back to rhel10 when the image comes out -->
-For this, we will assume that you are using the MariaDB 11.8 container image from the
-Quay.io registry called `fedora/mariadb-118`.
+For this, we will assume that you are using the MariaDB {{ spec.version }} container image from the
+Quay.io registry called `{{ spec.image_name }}`.
 If you want to set only the mandatory environment variables and not store
 the database in a host directory, execute the following command:
 
 ```
-$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 fedora/mariadb-118
+$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.rhel_image_name }}
 ```
 
 This will create a container named `mariadb_database` running MySQL with database
@@ -194,21 +193,20 @@ variable with the full path of the file you wish to use. For example, the defaul
 location is `/etc/my.cnf` but you can change it to `/etc/mysql/my.cnf` by setting
  `MYSQL_DEFAULTS_FILE=/etc/mysql/my.cnf`
 
-<!--- TODO: put back when the rhel/centos images are released
 Extending image
 ---------------
 This image can be extended in Openshift using the `Source` build strategy or via the standalone
 [source-to-image](https://docs.openshift.com/container-platform/4.14/openshift_images/create-images.html#images-create-s2i_create-images) application (where available).
-For this, we will assume that you are using the `rhel10/mariadb-118` image,
-available via `mariadb:11.8` imagestream tag in Openshift.
+For this, we will assume that you are using the `{{ spec.rhel_image_name }}` image,
+available via `mariadb:{{ spec.version }}` imagestream tag in Openshift.
 
 
-For example, to build a customized MariaDB database image `my-mariadb-rhel10`
+For example, to build a customized MariaDB database image `{{ spec.s2i_example_name }}`
 with a configuration from `https://github.com/sclorg/mariadb-container/tree/master/examples/extend-image` run:
 
 ```
-$ oc new-app mariadb:11.8~https://github.com/sclorg/mariadb-container.git \
-    --name my-mariadb-rhel10 \
+$ oc new-app mariadb:{{ spec.version }}~https://github.com/sclorg/mariadb-container.git \
+    --name {{ spec.s2i_example_name }} \
     --context-dir=examples/extend-image \
     --env MYSQL_OPERATIONS_USER=opuser \
     --env MYSQL_OPERATIONS_PASSWORD=oppass \
@@ -220,7 +218,7 @@ $ oc new-app mariadb:11.8~https://github.com/sclorg/mariadb-container.git \
 or via s2i:
 
 ```
-$ s2i build --context-dir=examples/extend-image https://github.com/sclorg/mariadb-container.git rhel10/mariadb-118 my-mariadb-rhel10
+$ s2i build --context-dir=examples/extend-image https://github.com/sclorg/mariadb-container.git {{ spec.rhel_image_name }} {{ spec.s2i_example_name }}
 ```
 
 The directory passed to Openshift can contain these directories:
@@ -266,7 +264,6 @@ every time the image is started using `podman run`. The directory has to be
 mounted into `/opt/app-root/src/` in the image
 (`-v ./image-configuration/:/opt/app-root/src/`).
 This overwrites customization built into the image.
--->
 
 Securing the connection with SSL
 --------------------------------
@@ -293,7 +290,7 @@ MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23)
 For version changes in Z part, the server's binary data format stays compatible and thus no
 special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
 steps as described at
-https://mariadb.com/kb/en/library/upgrading-from-mariadb-104-to-mariadb-1011/
+{{ spec.upgrade_doc_url }}
 
 Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
 the only exception is ugrading from MariaDB 5.5 to MariaDB 10.0 and from MariaDB 10.3 to 10.11.
@@ -368,395 +365,3 @@ the Dockerfile for RHEL10 is called Dockerfile.rhel10,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.
-{% else -%}
-{% if spec.version == "10.3" -%}
-MariaDB {{ spec.version }} SQL Database Server Docker image
-{% elif spec.version == "10.5" -%}
-MariaDB {{ spec.version }} SQL Database Server Docker image
-{% else -%}
-MariaDB {{ spec.version }} SQL Database Server Container image
-{% endif -%}
-=============================================
-
-This container image includes MariaDB {{ spec.version }} SQL database server for OpenShift and general usage.
-{% if spec.version == "10.3" -%}
-The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-{% elif spec.version == "10.5" -%}
-Users can choose between RHEL and CentOS Stream based images.
-The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-and the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg).
-{% else -%}
-Users can choose between RHEL, CentOS Stream and Fedora based images.
-The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS Stream images are available on [Quay.io/sclorg](https://quay.io/organization/sclorg),
-and the Fedora images are available in [Fedora Registry](https://quay.io/organization/fedora).
-{% endif -%}
-The resulting image can be run using [podman](https://github.com/containers/libpod).
-
-Note: while the examples in this README call `podman`, you can replace any such calls by `docker` with the same arguments
-
-Description
------------
-
-This container image provides a containerized packaging of the MariaDB mysqld daemon
-and client application. The mysqld server daemon accepts connections from clients
-and provides access to content from MySQL databases on behalf of the clients.
-You can find more information on the MariaDB project from the project Web site
-(https://mariadb.org/).
-
-
-Usage
------
-
-For this, we will assume that you are using the MariaDB {{ spec.version }} container image from the
-Red Hat Container Catalog called `{{ spec.rhel_image_name }}`.
-If you want to set only the mandatory environment variables and not store
-the database in a host directory, execute the following command:
-
-```
-$ podman run -d --name mariadb_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 {{ spec.rhel_image_name }}
-```
-
-This will create a container named `mariadb_database` running MySQL with database
-`db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
-to the host. If you want your database to be persistent across container executions,
-also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
-data directory.
-
-If the database directory is not initialized, the entrypoint script will first
-run [`mysql_install_db`](https://dev.mysql.com/doc/refman/5.6/en/mysql-install-db.html)
-and setup necessary database users and passwords. After the database is initialized,
-or if it was already present, `mysqld` is executed and will run as PID 1. You can
- stop the detached container by running `podman stop mariadb_database`.
-
-
-Environment variables and volumes
----------------------------------
-
-The image recognizes the following environment variables that you can set during
-initialization by passing `-e VAR=VALUE` to the Docker run command.
-
-**`MYSQL_USER`**  
-       User name for MySQL account to be created
-
-**`MYSQL_PASSWORD`**  
-       Password for the user account
-
-**`MYSQL_DATABASE`**  
-       Database name
-
-**`MYSQL_ROOT_PASSWORD`**  
-       Password for the root user (optional)
-
-**`MYSQL_CHARSET`**  
-       Default character set (optional)
-
-**`MYSQL_COLLATION`**  
-       Default collation (optional)
-
-
-The following environment variables influence the MySQL configuration file. They are all optional.
-
-**`MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)`**  
-       Sets how the table names are stored and compared
-
-**`MYSQL_MAX_CONNECTIONS (default: 151)`**  
-       The maximum permitted number of simultaneous client connections
-
-**`MYSQL_MAX_ALLOWED_PACKET (default: 200M)`**  
-       The maximum size of one packet or any generated/intermediate string
-
-**`MYSQL_FT_MIN_WORD_LEN (default: 4)`**  
-       The minimum length of the word to be included in a FULLTEXT index
-
-**`MYSQL_FT_MAX_WORD_LEN (default: 20)`**  
-       The maximum length of the word to be included in a FULLTEXT index
-
-**`MYSQL_AIO (default: 1)`**  
-       Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529
-
-**`MYSQL_TABLE_OPEN_CACHE (default: 400)`**  
-       The number of open tables for all threads
-
-**`MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)`**  
-       The size of the buffer used for index blocks
-
-**`MYSQL_SORT_BUFFER_SIZE (default: 256K)`**  
-       The size of the buffer used for sorting
-
-**`MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)`**  
-       The size of the buffer used for a sequential scan
-
-**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)`**  
-       The size of the buffer pool where InnoDB caches table and index data
-
-**`MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available memory)`**  
-       The size of each log file in a log group
-
-**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)`**  
-       The size of the buffer that InnoDB uses to write to the log files on disk
-
-**`MYSQL_DEFAULTS_FILE (default: /etc/my.cnf)`**  
-       Point to an alternative configuration file
-
-**`MYSQL_BINLOG_FORMAT (default: statement)`**  
-       Set sets the binlog format, supported values are `row` and `statement`
-
-**`MYSQL_LOG_QUERIES_ENABLED (default: 0)`**  
-       To enable query logging set this to `1`
-
-
-You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
-
-**`/var/lib/mysql/data`**  
-       MySQL data directory
-
-
-**Notice: When mouting a directory from the host into the container, ensure that the mounted
-directory has the appropriate permissions and that the owner and group of the directory
-matches the user UID or name which is running inside the container.**
-
-
-MariaDB auto-tuning
--------------------
-
-When the MySQL image is run with the `--memory` parameter set and you didn't
-specify value for some parameters, their values will be automatically
-calculated based on the available memory.
-
-**`MYSQL_KEY_BUFFER_SIZE (default: 10%)`**  
-       `key_buffer_size`
-
-**`MYSQL_READ_BUFFER_SIZE (default: 5%)`**  
-       `read_buffer_size`
-
-**`MYSQL_INNODB_BUFFER_POOL_SIZE (default: 50%)`**  
-       `innodb_buffer_pool_size`
-
-**`MYSQL_INNODB_LOG_FILE_SIZE (default: 15%)`**  
-       `innodb_log_file_size`
-
-**`MYSQL_INNODB_LOG_BUFFER_SIZE (default: 15%)`**  
-       `innodb_log_buffer_size`
-
-
-
-MySQL root user
----------------------------------
-The root user has no password set by default, only allowing local connections.
-You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
-will allow you to login to the root account remotely. Local connections will
-still not require a password.
-
-To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
-the container.
-
-
-Changing passwords
-------------------
-
-Since passwords are part of the image configuration, the only supported method
-to change passwords for the database user (`MYSQL_USER`) and root user is by
-changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
-respectively.
-
-Changing database passwords through SQL statements or any way other than through
-the environment variables aforementioned will cause a mismatch between the
-values stored in the variables and the actual passwords. Whenever a database
-container starts it will reset the passwords to the values stored in the
-environment variables.
-
-
-Default my.cnf file
--------------------
-With environment variables we are able to customize a lot of different parameters
-or configurations for the mysql bootstrap configurations. If you'd prefer to use
-your own configuration file, you can override the `MYSQL_DEFAULTS_FILE` env
-variable with the full path of the file you wish to use. For example, the default
-location is `/etc/my.cnf` but you can change it to `/etc/mysql/my.cnf` by setting
- `MYSQL_DEFAULTS_FILE=/etc/mysql/my.cnf`
-
-
-Extending image
----------------
-This image can be extended in Openshift using the `Source` build strategy or via the standalone
-[source-to-image](https://docs.openshift.com/container-platform/4.14/openshift_images/create-images.html#images-create-s2i_create-images) application (where available).
-For this, we will assume that you are using the `{{ spec.rhel_image_name }}` image,
-available via `mariadb:{{ spec.version }}` imagestream tag in Openshift.
-
-
-For example, to build a customized MariaDB database image `{{ spec.s2i_example_name }}`
-with a configuration from `https://github.com/sclorg/mariadb-container/tree/master/examples/extend-image` run:
-
-```
-$ oc new-app mariadb:{{ spec.version }}~https://github.com/sclorg/mariadb-container.git \
-    --name {{ spec.s2i_example_name }} \
-    --context-dir=examples/extend-image \
-    --env MYSQL_OPERATIONS_USER=opuser \
-    --env MYSQL_OPERATIONS_PASSWORD=oppass \
-    --env MYSQL_DATABASE=opdb \
-    --env MYSQL_USER=user \
-    --env MYSQL_PASSWORD=pass
-```
-
-or via s2i:
-
-```
-$ s2i build --context-dir=examples/extend-image https://github.com/sclorg/mariadb-container.git {{ spec.rhel_image_name }} {{ spec.s2i_example_name }}
-```
-
-The directory passed to Openshift can contain these directories:
-
-`mysql-cfg/`
-    When starting the container, files from this directory will be used as
-    a configuration for the `mysqld` daemon.
-    `envsubst` command is run on this file to still allow customization of
-    the image using environmental variables
-
-`mysql-pre-init/`
-    Shell scripts (`*.sh`) available in this directory are sourced before
-    `mysqld` daemon is started.
-
-`mysql-init/`
-    Shell scripts (`*.sh`) available in this directory are sourced when
-    `mysqld` daemon is started locally. In this phase, use `${mysql_flags}`
-    to connect to the locally running daemon, for example `mysql $mysql_flags < dump.sql`
-
-Variables that can be used in the scripts provided to s2i:
-
-`$mysql_flags`
-    arguments for the `mysql` tool that will connect to the locally running `mysqld` during initialization
-
-`$MYSQL_RUNNING_AS_MASTER`
-    variable defined when the container is run with `run-mysqld-master` command
-
-`$MYSQL_RUNNING_AS_SLAVE`
-    variable defined when the container is run with `run-mysqld-slave` command
-
-`$MYSQL_DATADIR_FIRST_INIT`
-    variable defined when the container was initialized from the empty data dir
-
-During the s2i build all provided files are copied into `/opt/app-root/src`
-directory into the resulting image. If some configuration files are present
-in the destination directory, files with the same name are overwritten.
-Also only one file with the same name can be used for customization and user
-provided files are preferred over default files in
-`/usr/share/container-scripts/mysql/`- so it is possible to overwrite them.
-
-Same configuration directory structure can be used to customize the image
-every time the image is started using `podman run`. The directory has to be
-mounted into `/opt/app-root/src/` in the image
-(`-v ./image-configuration/:/opt/app-root/src/`).
-This overwrites customization built into the image.
-
-
-Securing the connection with SSL
---------------------------------
-In order to secure the connection with SSL, use the extending feature described
-above. In particular, put the SSL certificates into a separate directory:
-
-    sslapp/mysql-certs/server-cert-selfsigned.pem
-    sslapp/mysql-certs/server-key.pem
-
-And then put a separate configuration file into mysql-cfg:
-
-    $> cat sslapp/mysql-cfg/ssl.cnf
-    [mysqld]
-    ssl-key=${APP_DATA}/mysql-certs/server-key.pem
-    ssl-cert=${APP_DATA}/mysql-certs/server-cert-selfsigned.pem
-
-Such a directory `sslapp` can then be mounted into the container with -v,
-or a new container image can be built using s2i.
-
-
-Upgrading and data directory version checking
----------------------------------------------
-
-MySQL and MariaDB use versions that consist of three numbers X.Y.Z (e.g. 5.6.23).
-For version changes in Z part, the server's binary data format stays compatible and thus no
-special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider doing manual
-steps as described at
-{{ spec.upgrade_doc_url }}
-
-Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
-the only exception is ugrading from {{ spec.upgrade_skip_note }}
-
-**Important**: Upgrading to a new version is always risky and users are expected to make a full
-back-up of all data before.
-
-A safer solution to upgrade is to dump all data using `mysqldump` or `mysqldbexport` and then
-load the data using `mysql` or `mysqldbimport` into an empty (freshly initialized) database.
-
-Another way of proceeding with the upgrade is starting the new version of the `mysqld` daemon
-and run `mysql_upgrade` right after the start. This so called in-place upgrade is generally
-faster for large data directory, but only possible if upgrading from the very previous version,
-so skipping versions is not supported.
-
-This container detects whether the data needs to be upgraded using `mysql_upgrade` and
-we can control it by setting `MYSQL_DATADIR_ACTION` variable, which can have one or more of the following values:
-
- * `upgrade-warn` -- If the data version can be determined and the data come from a different version
-   of the daemon, a warning is printed but the container starts. This is the default value.
-   Since historically the version file `mysql_upgrade_info` was not created, when using this option,
-   the version file is created if not exist, but no `mysql_upgrade` will be called.
-   However, this automatic creation will be removed after few months, since the version should be
-   created on most deployments at that point.
- * `upgrade-auto` -- `mysql_upgrade` is run at the beginning of the container start, when the local
-   daemon is running, but only if the data version can be determined and the data come
-   with the very previous version. A warning is printed if the data come from even older
-   or newer version. This value effectively enables automatic upgrades,
-   but it is always risky and users should still back-up all the data before starting the newer container.
-   Set this option only if you have very good back-ups at any moment and you are fine to fail-over
-   from the back-up.
- * `upgrade-force` -- `mysql_upgrade --force` is run at the beginning of the container start, when the local
-   daemon is running, no matter what version of the daemon the data come from.
-   This is also the way to create the missing version file `mysql_upgrade_info` if not present
-   in the root of the data directory; this file holds information about the version of the data.
-
-There are also some other actions that you may want to run at the beginning of the container start,
-when the local daemon is running, no matter what version of the data is detected:
-
- * `optimize` -- runs `mysqlcheck --optimize`. It optimizes all the tables.
- * `analyze` -- runs `mysqlcheck --analyze`. It analyzes all the tables.
- * `disable` -- nothing is done regarding data directory version.
-
-Multiple values are separated by comma and run in-order, e.g. `MYSQL_DATADIR_ACTION="optimize,analyze"`.
-
-
-Changing the replication binlog_format
---------------------------------------
-Some applications may wish to use `row` binlog_formats (for example, those built
-  with change-data-capture in mind). The default replication/binlog format is
-  `statement` but to change it you can set the `MYSQL_BINLOG_FORMAT` environment
-  variable. For example `MYSQL_BINLOG_FORMAT=row`. Now when you run the database
-  with `master` replication turned on (ie, set the Docker/container `cmd` to be
-`run-mysqld-master`) the binlog will emit the actual data for the rows that change
-as opposed to the statements (ie, DML like insert...) that caused the change.
-
-
-Troubleshooting
----------------
-The mysqld deamon in the container logs to the standard output, so the log is available in the container log. The log can be examined by running:
-
-    podman logs <container>
-
-
-See also
---------
-Dockerfile and other sources for this container image are available on
-https://github.com/sclorg/mariadb-container.
-{% if spec.version == "10.3" -%}
-In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8.
-{% elif spec.version == "10.5" -%}
-In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
-the Dockerfile for RHEL9 is called Dockerfile.rhel9
-and the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s.
-{% else -%}
-In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
-the Dockerfile for RHEL9 is called Dockerfile.rhel9,
-the Dockerfile for RHEL10 is called Dockerfile.rhel10,
-the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
-the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
-and the Dockerfile for Fedora is called Dockerfile.fedora.
-{% endif -%}
-{% endif -%}


### PR DESCRIPTION
Add dist-gen source files.

  What was changed in Dockerfiles.
  - SUMMARY uses now version instead of ${MYSQL_VERSION}
  - io.k8s. uses hardcoded version as well.
  - STI_SCRIPTS_PATH is now unified.
  - COPY now uses hardcoded version.

  New files and directories are:
  - src
  - specs
  - manifest.yml

Build-and-push is updated.


<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4659957827"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4830200903","data":[{"id":"d2add8a5-3380-49c9-a68e-e37ac1e1928f","name":"Fedora - 11.8","status":"complete","outcome":"passed","runTime":571.060029,"created":"2026-06-29T07:45:48.970254","updated":"2026-06-29T07:45:48.970260","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d2add8a5-3380-49c9-a68e-e37ac1e1928f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d2add8a5-3380-49c9-a68e-e37ac1e1928f/pipeline.log\">pipeline</a>"]},{"id":"eb6b98f3-73a7-4313-8641-6bba80ca7c03","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":628.987995,"created":"2026-06-29T07:45:50.088489","updated":"2026-06-29T07:45:50.088498","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/eb6b98f3-73a7-4313-8641-6bba80ca7c03\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/eb6b98f3-73a7-4313-8641-6bba80ca7c03/pipeline.log\">pipeline</a>"]},{"id":"82074b03-3f7a-406e-9d97-207741ff1b4e","name":"Fedora - PyTest - 11.8","status":"complete","outcome":"passed","runTime":804.101505,"created":"2026-06-29T07:45:51.829488","updated":"2026-06-29T07:45:51.829496","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/82074b03-3f7a-406e-9d97-207741ff1b4e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/82074b03-3f7a-406e-9d97-207741ff1b4e/pipeline.log\">pipeline</a>"]},{"id":"acebe77a-d5ff-4d6c-99a0-813dbaa81054","name":"Fedora - PyTest - 10.11","status":"complete","outcome":"passed","runTime":773.647555,"created":"2026-06-29T07:45:50.485186","updated":"2026-06-29T07:45:50.485194","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/acebe77a-d5ff-4d6c-99a0-813dbaa81054\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/acebe77a-d5ff-4d6c-99a0-813dbaa81054/pipeline.log\">pipeline</a>"]},{"id":"fd3980ec-abff-4e3e-b893-c3158087673c","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":742.947021,"created":"2026-06-29T07:45:51.388168","updated":"2026-06-29T07:45:51.388176","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd3980ec-abff-4e3e-b893-c3158087673c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd3980ec-abff-4e3e-b893-c3158087673c/pipeline.log\">pipeline</a>"]},{"id":"b3312b3b-eff0-4002-8332-068777512a3f","name":"CentOS Stream 9 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":938.684765,"created":"2026-06-29T07:45:50.530291","updated":"2026-06-29T07:45:50.530299","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b3312b3b-eff0-4002-8332-068777512a3f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b3312b3b-eff0-4002-8332-068777512a3f/pipeline.log\">pipeline</a>"]},{"id":"ec8be8b9-1753-490d-b92b-d4d31e830b91","name":"CentOS Stream 9 - PyTest - 10.5","status":"complete","outcome":"error","runTime":876.230149,"created":"2026-06-29T11:35:51.206475","updated":"2026-06-29T11:35:51.206484","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ec8be8b9-1753-490d-b92b-d4d31e830b91\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ec8be8b9-1753-490d-b92b-d4d31e830b91/pipeline.log\">pipeline</a>"]},{"id":"dfbbfd8c-cf6a-4aae-86c4-43fbe4482514","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":957.708266,"created":"2026-06-29T07:45:51.074783","updated":"2026-06-29T07:45:51.074790","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dfbbfd8c-cf6a-4aae-86c4-43fbe4482514\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dfbbfd8c-cf6a-4aae-86c4-43fbe4482514/pipeline.log\">pipeline</a>"]},{"id":"69b77bff-4559-43ca-a027-63777540e61d","name":"RHEL8 - PyTest - 10.5","status":"complete","outcome":"passed","runTime":1060.61855,"created":"2026-06-29T07:45:51.060220","updated":"2026-06-29T07:45:51.060229","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/69b77bff-4559-43ca-a027-63777540e61d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/69b77bff-4559-43ca-a027-63777540e61d/pipeline.log\">pipeline</a>"]},{"id":"300ccf39-f1f7-402b-b0cf-0aec97966088","name":"RHEL10 - Unsubscribed host - 11.8","status":"complete","outcome":"passed","runTime":1178.454915,"created":"2026-06-29T07:45:50.254465","updated":"2026-06-29T07:45:50.254474","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/300ccf39-f1f7-402b-b0cf-0aec97966088\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/300ccf39-f1f7-402b-b0cf-0aec97966088/pipeline.log\">pipeline</a>"]},{"id":"6d8aca2a-6d70-43c7-8fd0-70e1ba6cc443","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1427.61513,"created":"2026-06-29T07:45:51.475273","updated":"2026-06-29T07:45:51.475279","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d8aca2a-6d70-43c7-8fd0-70e1ba6cc443\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d8aca2a-6d70-43c7-8fd0-70e1ba6cc443/pipeline.log\">pipeline</a>"]},{"id":"a6ca2e73-59d5-46ef-98b4-f39fb42ea285","name":"RHEL10 - Unsubscribed host - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1391.469165,"created":"2026-06-29T07:45:51.283400","updated":"2026-06-29T07:45:51.283406","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6ca2e73-59d5-46ef-98b4-f39fb42ea285\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6ca2e73-59d5-46ef-98b4-f39fb42ea285/pipeline.log\">pipeline</a>"]},{"id":"009106d4-36cb-4589-8bc9-42fca83a93ff","name":"RHEL10 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1355.105672,"created":"2026-06-29T07:45:49.070100","updated":"2026-06-29T07:45:49.070106","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/009106d4-36cb-4589-8bc9-42fca83a93ff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/009106d4-36cb-4589-8bc9-42fca83a93ff/pipeline.log\">pipeline</a>"]},{"id":"931901ed-1a31-4506-90dd-79b9c30858fd","name":"RHEL9 - Unsubscribed host - 11.8","status":"complete","outcome":"passed","runTime":1467.945747,"created":"2026-06-29T07:45:49.272059","updated":"2026-06-29T07:45:49.272064","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/931901ed-1a31-4506-90dd-79b9c30858fd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/931901ed-1a31-4506-90dd-79b9c30858fd/pipeline.log\">pipeline</a>"]},{"id":"48647d51-a6a4-45d6-a295-1c7b1c52481c","name":"RHEL9 - 11.8","status":"complete","outcome":"passed","runTime":1461.232409,"created":"2026-06-29T07:45:48.902190","updated":"2026-06-29T07:45:48.902196","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/48647d51-a6a4-45d6-a295-1c7b1c52481c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/48647d51-a6a4-45d6-a295-1c7b1c52481c/pipeline.log\">pipeline</a>"]},{"id":"aa7cb0ad-ff34-44c1-ab20-3e08bae49ee5","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":653.619098,"created":"2026-06-29T08:06:17.596384","updated":"2026-06-29T08:06:17.596391","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/aa7cb0ad-ff34-44c1-ab20-3e08bae49ee5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/aa7cb0ad-ff34-44c1-ab20-3e08bae49ee5/pipeline.log\">pipeline</a>"]},{"id":"e69f330e-b206-4ad9-a312-b8bf2ab45fda","name":"CentOS Stream 9 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":867.848396,"created":"2026-06-29T08:02:15.482243","updated":"2026-06-29T08:02:15.482249","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e69f330e-b206-4ad9-a312-b8bf2ab45fda\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e69f330e-b206-4ad9-a312-b8bf2ab45fda/pipeline.log\">pipeline</a>"]},{"id":"769c5e22-395c-4000-996d-773cdffe30a6","name":"CentOS Stream 10 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":835.61412,"created":"2026-06-29T08:06:15.480487","updated":"2026-06-29T08:06:15.480496","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/769c5e22-395c-4000-996d-773cdffe30a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/769c5e22-395c-4000-996d-773cdffe30a6/pipeline.log\">pipeline</a>"]},{"id":"8092cb87-6a14-42ee-88a4-ca71efac161d","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":1453.863076,"created":"2026-06-29T07:56:09.392306","updated":"2026-06-29T07:56:09.392314","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8092cb87-6a14-42ee-88a4-ca71efac161d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8092cb87-6a14-42ee-88a4-ca71efac161d/pipeline.log\">pipeline</a>"]},{"id":"85643281-3657-4af1-a9a4-ab7d2ce1b8f6","name":"RHEL8 - PyTest - 10.3","status":"complete","outcome":"passed","runTime":1179.289274,"created":"2026-06-29T08:02:10.221514","updated":"2026-06-29T08:02:10.221522","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/85643281-3657-4af1-a9a4-ab7d2ce1b8f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/85643281-3657-4af1-a9a4-ab7d2ce1b8f6/pipeline.log\">pipeline</a>"]},{"id":"5b366cbe-cb08-4804-86eb-f54b77691666","name":"RHEL10 - Unsubscribed host - 10.11","status":"complete","outcome":"passed","runTime":1194.70039,"created":"2026-06-29T08:04:09.256436","updated":"2026-06-29T08:04:09.256453","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b366cbe-cb08-4804-86eb-f54b77691666\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b366cbe-cb08-4804-86eb-f54b77691666/pipeline.log\">pipeline</a>"]},{"id":"f37e0c4e-7be7-48ea-8ca3-e7ae6b61c94d","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":731.877892,"created":"2026-06-29T08:10:13.575443","updated":"2026-06-29T08:10:13.575450","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f37e0c4e-7be7-48ea-8ca3-e7ae6b61c94d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f37e0c4e-7be7-48ea-8ca3-e7ae6b61c94d/pipeline.log\">pipeline</a>"]},{"id":"28232e97-877e-4e00-ba9d-2539192c452f","name":"CentOS Stream 10 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":888.6849,"created":"2026-06-29T08:10:11.441987","updated":"2026-06-29T08:10:11.441992","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/28232e97-877e-4e00-ba9d-2539192c452f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/28232e97-877e-4e00-ba9d-2539192c452f/pipeline.log\">pipeline</a>"]},{"id":"4fa79764-5a7d-4ee1-98da-efbc91890869","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":914.054865,"created":"2026-06-29T08:10:19.777523","updated":"2026-06-29T08:10:19.777531","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4fa79764-5a7d-4ee1-98da-efbc91890869\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4fa79764-5a7d-4ee1-98da-efbc91890869/pipeline.log\">pipeline</a>"]},{"id":"be202ab1-82f1-4636-9cc8-8a7425ea8432","name":"RHEL9 - Unsubscribed host - 10.11","status":"complete","outcome":"passed","runTime":1761.07328,"created":"2026-06-29T07:58:12.681202","updated":"2026-06-29T07:58:12.681210","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/be202ab1-82f1-4636-9cc8-8a7425ea8432\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/be202ab1-82f1-4636-9cc8-8a7425ea8432/pipeline.log\">pipeline</a>"]},{"id":"a44aa66e-786a-4a7e-85e3-af7c1cc33fcf","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":1136.008275,"created":"2026-06-29T08:12:06.801084","updated":"2026-06-29T08:12:06.801092","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a44aa66e-786a-4a7e-85e3-af7c1cc33fcf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a44aa66e-786a-4a7e-85e3-af7c1cc33fcf/pipeline.log\">pipeline</a>"]},{"id":"0b4d6172-dc5b-43fd-88c2-94322c045120","name":"RHEL8 - PyTest - 10.11","status":"complete","outcome":"error","runTime":3672.29949,"created":"2026-06-29T11:35:51.166688","updated":"2026-06-29T11:35:51.166693","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b4d6172-dc5b-43fd-88c2-94322c045120\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b4d6172-dc5b-43fd-88c2-94322c045120/pipeline.log\">pipeline</a>"]},{"id":"a716a309-305e-4072-ad3a-22e7babb49a0","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1806.070892,"created":"2026-06-29T08:00:16.485702","updated":"2026-06-29T08:00:16.485709","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a716a309-305e-4072-ad3a-22e7babb49a0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a716a309-305e-4072-ad3a-22e7babb49a0/pipeline.log\">pipeline</a>"]},{"id":"61e1c70a-f6a6-42c6-b473-bd19c400569c","name":"RHEL10 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1886.652451,"created":"2026-06-29T08:00:13.767608","updated":"2026-06-29T08:00:13.767614","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61e1c70a-f6a6-42c6-b473-bd19c400569c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61e1c70a-f6a6-42c6-b473-bd19c400569c/pipeline.log\">pipeline</a>"]},{"id":"b2c23533-2835-469e-b263-7a1c7d4c971c","name":"RHEL9 - Unsubscribed host - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1971.565775,"created":"2026-06-29T08:00:08.192799","updated":"2026-06-29T08:00:08.192805","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2c23533-2835-469e-b263-7a1c7d4c971c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2c23533-2835-469e-b263-7a1c7d4c971c/pipeline.log\">pipeline</a>"]},{"id":"b9549fde-4afd-4844-8632-f29d6e2a03de","name":"RHEL9 - Unsubscribed host - PyTest - 11.8","status":"complete","outcome":"passed","runTime":2049.277818,"created":"2026-06-29T08:00:05.024548","updated":"2026-06-29T08:00:05.024558","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9549fde-4afd-4844-8632-f29d6e2a03de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9549fde-4afd-4844-8632-f29d6e2a03de/pipeline.log\">pipeline</a>"]},{"id":"4bb0e96f-f300-4326-a248-27b62eeee8da","name":"RHEL9 - Unsubscribed host - PyTest - 10.5","status":"complete","outcome":"passed","runTime":1441.079709,"created":"2026-06-29T08:12:08.601355","updated":"2026-06-29T08:12:08.601361","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bb0e96f-f300-4326-a248-27b62eeee8da\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bb0e96f-f300-4326-a248-27b62eeee8da/pipeline.log\">pipeline</a>"]},{"id":"025d2347-6ba9-4c9e-bb14-056c6ec7a5da","name":"RHEL9 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1596.667072,"created":"2026-06-29T08:10:14.584903","updated":"2026-06-29T08:10:14.584911","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/025d2347-6ba9-4c9e-bb14-056c6ec7a5da\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/025d2347-6ba9-4c9e-bb14-056c6ec7a5da/pipeline.log\">pipeline</a>"]},{"id":"bfaf0e3f-f999-4bb2-9800-643006043d07","name":"RHEL9 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":2348.357581,"created":"2026-06-29T08:00:09.984569","updated":"2026-06-29T08:00:09.984577","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfaf0e3f-f999-4bb2-9800-643006043d07\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfaf0e3f-f999-4bb2-9800-643006043d07/pipeline.log\">pipeline</a>"]},{"id":"7c190b97-e5f2-41e0-a15b-bbd9c4451bfa","name":"RHEL9 - Unsubscribed host - 10.5","runTime":4782.507529,"created":"2026-06-29T11:35:51.095660","updated":"2026-06-29T11:35:51.095670","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c190b97-e5f2-41e0-a15b-bbd9c4451bfa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c190b97-e5f2-41e0-a15b-bbd9c4451bfa/pipeline.log\">pipeline</a>"]}]} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generation support for multiple MariaDB image variants and distributions.
  * Introduced new Fedora and template-based container image build definitions.

* **Bug Fixes**
  * Standardized MariaDB 10.3, 10.5, 10.11, and 11.8 image metadata and naming across builds.
  * Updated package installation and build paths for newer distro/image combinations.

* **Documentation**
  * Refreshed container README files with updated upgrade guidance, usage examples, and supported image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->