### PR TITLE
OKD-380: Add missing namespace to image trigger annotations

### DIFF
--- a/examples/mariadb-ephemeral-template.json
+++ b/examples/mariadb-ephemeral-template.json
@@ -67,7 +67,7 @@
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {

--- a/examples/mariadb-persistent-template.json
+++ b/examples/mariadb-persistent-template.json
@@ -84,7 +84,7 @@
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "template.alpha.openshift.io/wait-for-ready": "true",
-          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"mariadb:${MARIADB_VERSION}\",\"namespace\":\"${NAMESPACE}\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {


### PR DESCRIPTION
## Problem

Deploying MariaDB from the OKD 4.22 Software Catalog fails with:

```
spec.containers[0].image: Invalid value: " ": must not have leading or trailing whitespace
```

Reported in https://github.com/okd-project/okd/issues/2337

## Root Cause

When templates were migrated from `DeploymentConfig` to `Deployment`, the `image.openshift.io/triggers` annotation dropped the `namespace` field from the `ImageStreamTag` reference. Without it, the image trigger controller defaults to the Deployment's own namespace instead of `openshift`, so it can't find the ImageStream and the container image is never resolved.

## Fix

Add `"namespace":"${NAMESPACE}"` to the trigger annotation's `from` object in both `mariadb-persistent` and `mariadb-ephemeral` templates. The `NAMESPACE` parameter already exists in both templates with a default value of `"openshift"`.

## Impact

These template files are the upstream source for `openshift/library` (via `make import`) and ultimately `openshift/cluster-samples-operator`. An immediate fix was applied directly to the operator in [openshift/cluster-samples-operator#701](https://github.com/openshift/cluster-samples-operator/pull/701). This upstream fix ensures the bug doesn't recur on the next sync.

<!-- issue-commentator = {"comment-id":"4775554420"} -->