### PR TITLE
Update container-common-scripts

### DIFF
--- a/11.8/root/usr/share/container-scripts/mysql/README.md
+++ b/11.8/root/usr/share/container-scripts/mysql/README.md
@@ -296,7 +296,7 @@ special upgrade procedure is needed. For upgrades from X.Y to X.Y+1, consider do
 steps as described at
 https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/upgrading/mariadb-community-server-upgrade-paths/upgrading-to-unmaintained-mariadb-releases/upgrading-from-mariadb-10-11-to-mariadb-11-0
 
-Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported;
+Skipping versions like from X.Y to X.Y+2 or downgrading to lower version is not supported.
 
 **Important**: Upgrading to a new version is always risky and users are expected to make a full
 back-up of all data before.

--- a/src/root/usr/share/container-scripts/mysql/README.md
+++ b/src/root/usr/share/container-scripts/mysql/README.md
@@ -22,6 +22,7 @@ and provides access to content from MySQL databases on behalf of the clients.
 You can find more information on the MariaDB project from the project Web site
 (https://mariadb.org/).
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
 
 Usage
 -----

--- a/test/test_container_replication.py
+++ b/test/test_container_replication.py
@@ -74,7 +74,7 @@ class TestMariaDBReplicationContainer:
             username="root",
             password="root",
         )
-        for _ in range(3):
+        for _ in range(10):
             result = self.db_wrapper_api.run_sql_command(
                 container_ip=master_cip,
                 username="root",
@@ -84,6 +84,9 @@ class TestMariaDBReplicationContainer:
                 sql_cmd="SHOW SLAVE HOSTS;",
                 podman_run_command="exec",
             )
+            if isinstance(result, bool):
+                sleep(3)
+                continue
             if slave_cip in result:
                 break
             sleep(3)


### PR DESCRIPTION
Only updates container-common-scripts
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"5237338649"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a link to Red Hat Enterprise Linux Application Streams lifecycle information for the MariaDB stream.
  * Clarified upgrade guidance with improved punctuation.
* **Bug Fixes**
  * Improved replication discovery reliability by retrying transient command results and extending the retry limit.
* **Chores**
  * Updated shared project content to the latest revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"5237525804","data":[{"id":"6fff4f97-8399-4dbd-917d-434f5ec2d02c","name":"CentOS Stream 9 - 10.11","status":"complete","outcome":"passed","runTime":839.276248,"created":"2026-08-10T10:42:35.960894","updated":"2026-08-10T10:42:35.960902","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6fff4f97-8399-4dbd-917d-434f5ec2d02c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6fff4f97-8399-4dbd-917d-434f5ec2d02c/pipeline.log\">pipeline</a>"]},{"id":"a8b96c5d-bfae-4ecc-84db-439d2938ed01","name":"RHEL8 - 10.3","status":"complete","outcome":"passed","runTime":988.245379,"created":"2026-08-10T10:28:10.523943","updated":"2026-08-10T10:28:10.523951","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8b96c5d-bfae-4ecc-84db-439d2938ed01\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8b96c5d-bfae-4ecc-84db-439d2938ed01/pipeline.log\">pipeline</a>"]},{"id":"e7f22551-386e-45a8-94c5-2fa7591109a3","name":"CentOS Stream 9 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1218.697402,"created":"2026-08-10T10:48:28.124868","updated":"2026-08-10T10:48:28.124876","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e7f22551-386e-45a8-94c5-2fa7591109a3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e7f22551-386e-45a8-94c5-2fa7591109a3/pipeline.log\">pipeline</a>"]},{"id":"d9768da5-9fab-434b-9eec-51f0b8655966","name":"CentOS Stream 10 - 11.8","status":"complete","outcome":"passed","runTime":708.577728,"created":"2026-08-10T10:28:08.663357","updated":"2026-08-10T10:28:08.663364","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d9768da5-9fab-434b-9eec-51f0b8655966\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d9768da5-9fab-434b-9eec-51f0b8655966/pipeline.log\">pipeline</a>"]},{"id":"5a9d954c-80ad-484d-b658-61372fefff94","name":"RHEL8 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1043.371367,"created":"2026-08-10T10:28:10.794264","updated":"2026-08-10T10:28:10.794273","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a9d954c-80ad-484d-b658-61372fefff94\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a9d954c-80ad-484d-b658-61372fefff94/pipeline.log\">pipeline</a>"]},{"id":"16fab43e-a50d-47be-ac6e-49ee115bf7b7","name":"RHEL9 - Unsubscribed host - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1314.008319,"created":"2026-08-10T10:28:10.019832","updated":"2026-08-10T10:28:10.019841","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/16fab43e-a50d-47be-ac6e-49ee115bf7b7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/16fab43e-a50d-47be-ac6e-49ee115bf7b7/pipeline.log\">pipeline</a>"]},{"id":"3d82310f-af71-4356-82c9-b6d57b378f3f","name":"RHEL9 - Unsubscribed host - 10.11","status":"complete","outcome":"passed","runTime":1295.310805,"created":"2026-08-10T07:49:55.577711","updated":"2026-08-10T07:49:55.577725","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3d82310f-af71-4356-82c9-b6d57b378f3f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3d82310f-af71-4356-82c9-b6d57b378f3f/pipeline.log\">pipeline</a>"]},{"id":"b79b74aa-8a0a-491b-b6f6-7d6c4122226f","name":"RHEL9 - Unsubscribed host - PyTest - 10.5","status":"complete","outcome":"passed","runTime":1296.115386,"created":"2026-08-10T10:42:48.240859","updated":"2026-08-10T10:42:48.240867","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b79b74aa-8a0a-491b-b6f6-7d6c4122226f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b79b74aa-8a0a-491b-b6f6-7d6c4122226f/pipeline.log\">pipeline</a>"]},{"id":"c8120236-d157-4b6b-bc57-7855ee4f35a9","name":"RHEL8 - 10.5","status":"complete","outcome":"passed","runTime":912.543957,"created":"2026-08-10T10:40:34.225588","updated":"2026-08-10T10:40:34.225596","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c8120236-d157-4b6b-bc57-7855ee4f35a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c8120236-d157-4b6b-bc57-7855ee4f35a9/pipeline.log\">pipeline</a>"]},{"id":"a763e62e-4934-488d-b54a-0ab56bb3e87a","name":"RHEL9 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1445.426875,"created":"2026-08-10T10:28:11.933851","updated":"2026-08-10T10:28:11.933858","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a763e62e-4934-488d-b54a-0ab56bb3e87a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a763e62e-4934-488d-b54a-0ab56bb3e87a/pipeline.log\">pipeline</a>"]},{"id":"0e7e722f-2e42-4e51-b35d-2d81c684d5ca","name":"RHEL9 - PyTest - 10.5","status":"complete","outcome":"passed","runTime":1909.098257,"created":"2026-08-10T10:48:31.846894","updated":"2026-08-10T10:48:31.846902","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e7e722f-2e42-4e51-b35d-2d81c684d5ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e7e722f-2e42-4e51-b35d-2d81c684d5ca/pipeline.log\">pipeline</a>"]},{"id":"2f82d05c-25d3-4b53-894e-f5a85a212f6a","name":"Fedora - 11.8","status":"complete","outcome":"passed","runTime":575.383339,"created":"2026-08-10T10:28:11.670256","updated":"2026-08-10T10:28:11.670263","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2f82d05c-25d3-4b53-894e-f5a85a212f6a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2f82d05c-25d3-4b53-894e-f5a85a212f6a/pipeline.log\">pipeline</a>"]},{"id":"f798d916-482c-40ae-b41b-9cf72c776198","name":"RHEL8 - PyTest - 10.5","status":"complete","outcome":"passed","runTime":1771.926153,"created":"2026-08-10T10:42:39.017345","updated":"2026-08-10T10:42:39.017353","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f798d916-482c-40ae-b41b-9cf72c776198\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f798d916-482c-40ae-b41b-9cf72c776198/pipeline.log\">pipeline</a>"]},{"id":"2146ba69-552f-410f-b39b-88eb5f0fdd33","name":"Fedora - 10.11","status":"complete","outcome":"passed","runTime":1027.299374,"created":"2026-08-10T10:52:36.074991","updated":"2026-08-10T10:52:36.074997","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2146ba69-552f-410f-b39b-88eb5f0fdd33\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2146ba69-552f-410f-b39b-88eb5f0fdd33/pipeline.log\">pipeline</a>"]},{"id":"1b99c28f-403e-40d8-9737-8630f20682e8","name":"CentOS Stream 10 - 10.11","status":"complete","outcome":"passed","runTime":697.125324,"created":"2026-08-10T10:28:19.013175","updated":"2026-08-10T10:28:19.013182","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1b99c28f-403e-40d8-9737-8630f20682e8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1b99c28f-403e-40d8-9737-8630f20682e8/pipeline.log\">pipeline</a>"]},{"id":"68bebcf0-b081-4eaa-b618-8587cbfe8bed","name":"CentOS Stream 9 - PyTest - 10.5","status":"complete","outcome":"passed","runTime":1223.140543,"created":"2026-08-10T10:46:35.063881","updated":"2026-08-10T10:46:35.063888","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/68bebcf0-b081-4eaa-b618-8587cbfe8bed\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/68bebcf0-b081-4eaa-b618-8587cbfe8bed/pipeline.log\">pipeline</a>"]},{"id":"a1658a8b-3e5e-4260-b090-31d8dbd4afbb","name":"Fedora - PyTest - 10.11","status":"complete","outcome":"passed","runTime":837.811896,"created":"2026-08-10T10:28:09.921631","updated":"2026-08-10T10:28:09.921638","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1658a8b-3e5e-4260-b090-31d8dbd4afbb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1658a8b-3e5e-4260-b090-31d8dbd4afbb/pipeline.log\">pipeline</a>"]},{"id":"0b37adc4-f777-4f66-b033-9d7da67b5acc","name":"RHEL9 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1684.811457,"created":"2026-08-10T10:40:45.722562","updated":"2026-08-10T10:40:45.722571","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b37adc4-f777-4f66-b033-9d7da67b5acc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b37adc4-f777-4f66-b033-9d7da67b5acc/pipeline.log\">pipeline</a>"]},{"id":"f3c5c149-5f70-495f-b008-97019110e470","name":"RHEL9 - 11.8","status":"complete","outcome":"passed","runTime":1903.056802,"created":"2026-08-10T10:46:43.238647","updated":"2026-08-10T10:46:43.238656","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3c5c149-5f70-495f-b008-97019110e470\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3c5c149-5f70-495f-b008-97019110e470/pipeline.log\">pipeline</a>"]},{"id":"a081f1b3-b709-4972-b380-2e3e51e63c66","name":"RHEL10 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1324.855873,"created":"2026-08-10T10:28:09.549939","updated":"2026-08-10T10:28:09.549946","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a081f1b3-b709-4972-b380-2e3e51e63c66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a081f1b3-b709-4972-b380-2e3e51e63c66/pipeline.log\">pipeline</a>"]},{"id":"58027e75-f99c-4d90-a825-52eb62613c6d","name":"RHEL9 - 10.5","status":"complete","outcome":"passed","runTime":1404.801044,"created":"2026-08-10T10:28:09.853333","updated":"2026-08-10T10:28:09.853341","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58027e75-f99c-4d90-a825-52eb62613c6d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58027e75-f99c-4d90-a825-52eb62613c6d/pipeline.log\">pipeline</a>"]},{"id":"55a21c1f-0b6b-4d3b-992a-9e625aae3f4a","name":"CentOS Stream 9 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1430.033561,"created":"2026-08-10T10:50:36.916723","updated":"2026-08-10T10:50:36.916730","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/55a21c1f-0b6b-4d3b-992a-9e625aae3f4a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/55a21c1f-0b6b-4d3b-992a-9e625aae3f4a/pipeline.log\">pipeline</a>"]},{"id":"3c7b24bc-9461-4e02-a23b-45ab58db1f81","name":"RHEL8 - 10.11","status":"complete","outcome":"passed","runTime":912.16489,"created":"2026-08-10T10:28:17.453492","updated":"2026-08-10T10:28:17.453502","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c7b24bc-9461-4e02-a23b-45ab58db1f81\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c7b24bc-9461-4e02-a23b-45ab58db1f81/pipeline.log\">pipeline</a>"]},{"id":"f0cf1b2e-23f1-4c05-9f50-100494e38bdc","name":"RHEL10 - Unsubscribed host - PyTest - 10.11","status":"complete","outcome":"passed","runTime":1506.463863,"created":"2026-08-10T10:42:33.996663","updated":"2026-08-10T10:42:33.996671","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0cf1b2e-23f1-4c05-9f50-100494e38bdc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0cf1b2e-23f1-4c05-9f50-100494e38bdc/pipeline.log\">pipeline</a>"]},{"id":"96b2d277-310f-46b1-bb48-96a1d9ae369f","name":"RHEL10 - Unsubscribed host - 11.8","status":"complete","outcome":"passed","runTime":1118.367803,"created":"2026-08-10T10:28:11.735163","updated":"2026-08-10T10:28:11.735173","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/96b2d277-310f-46b1-bb48-96a1d9ae369f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/96b2d277-310f-46b1-bb48-96a1d9ae369f/pipeline.log\">pipeline</a>"]},{"id":"532dbcae-19cc-4864-a278-5d18af32c16b","name":"RHEL9 - 10.11","status":"complete","outcome":"passed","runTime":1366.811558,"created":"2026-08-10T10:52:33.703370","updated":"2026-08-10T10:52:33.703377","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/532dbcae-19cc-4864-a278-5d18af32c16b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/532dbcae-19cc-4864-a278-5d18af32c16b/pipeline.log\">pipeline</a>"]},{"id":"3105ce9d-c5d0-4107-8aca-4fde739c0615","name":"CentOS Stream 10 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":822.289164,"created":"2026-08-10T10:28:10.710556","updated":"2026-08-10T10:28:10.710562","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3105ce9d-c5d0-4107-8aca-4fde739c0615\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3105ce9d-c5d0-4107-8aca-4fde739c0615/pipeline.log\">pipeline</a>"]},{"id":"de079e55-497a-4fdb-8438-c995fb0cd82a","name":"RHEL9 - Unsubscribed host - 10.5","runTime":1891.842347,"created":"2026-08-10T10:54:51.840944","updated":"2026-08-10T10:54:51.840953","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/de079e55-497a-4fdb-8438-c995fb0cd82a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/de079e55-497a-4fdb-8438-c995fb0cd82a/pipeline.log\">pipeline</a>"]},{"id":"986f79df-18f4-4c62-bdd0-2aca6f4fecf9","name":"CentOS Stream 10 - PyTest - 10.11","status":"complete","outcome":"passed","runTime":833.813616,"created":"2026-08-10T10:28:11.879992","updated":"2026-08-10T10:28:11.879998","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/986f79df-18f4-4c62-bdd0-2aca6f4fecf9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/986f79df-18f4-4c62-bdd0-2aca6f4fecf9/pipeline.log\">pipeline</a>"]},{"id":"a6cc0eb6-e9f1-4a86-bc9d-4cf15d867273","name":"RHEL10 - 10.11","status":"complete","outcome":"passed","runTime":1183.141359,"created":"2026-08-10T10:28:09.294396","updated":"2026-08-10T10:28:09.294405","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6cc0eb6-e9f1-4a86-bc9d-4cf15d867273\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6cc0eb6-e9f1-4a86-bc9d-4cf15d867273/pipeline.log\">pipeline</a>"]},{"id":"59d99f26-99c1-404f-92c7-f7f323f8c30e","name":"RHEL9 - Unsubscribed host - 11.8","status":"complete","outcome":"passed","runTime":1346.865356,"created":"2026-08-10T08:15:38.151655","updated":"2026-08-10T08:15:38.151662","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/59d99f26-99c1-404f-92c7-f7f323f8c30e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/59d99f26-99c1-404f-92c7-f7f323f8c30e/pipeline.log\">pipeline</a>"]},{"id":"eeaf276a-7cc9-4cda-84af-c04b9b04a2a8","name":"RHEL9 - Unsubscribed host - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1579.491158,"created":"2026-08-10T10:42:28.797460","updated":"2026-08-10T10:42:28.797465","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eeaf276a-7cc9-4cda-84af-c04b9b04a2a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eeaf276a-7cc9-4cda-84af-c04b9b04a2a8/pipeline.log\">pipeline</a>"]},{"id":"df1b8348-08fe-41ae-a145-ac8563a8ce72","name":"RHEL10 - 11.8","status":"complete","outcome":"passed","runTime":1125.721991,"created":"2026-08-10T10:28:10.729751","updated":"2026-08-10T10:28:10.729759","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df1b8348-08fe-41ae-a145-ac8563a8ce72\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df1b8348-08fe-41ae-a145-ac8563a8ce72/pipeline.log\">pipeline</a>"]},{"id":"c212e865-5551-40a1-9d6b-b74c7bee0736","name":"CentOS Stream 9 - 11.8","status":"complete","outcome":"passed","runTime":759.19171,"created":"2026-08-10T10:28:11.380892","updated":"2026-08-10T10:28:11.380897","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c212e865-5551-40a1-9d6b-b74c7bee0736\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c212e865-5551-40a1-9d6b-b74c7bee0736/pipeline.log\">pipeline</a>"]},{"id":"53dc828f-ede6-4d47-8b28-635a5f29045e","name":"Fedora - PyTest - 11.8","status":"complete","outcome":"passed","runTime":738.799802,"created":"2026-08-10T10:28:17.013494","updated":"2026-08-10T10:28:17.013615","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/53dc828f-ede6-4d47-8b28-635a5f29045e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/53dc828f-ede6-4d47-8b28-635a5f29045e/pipeline.log\">pipeline</a>"]},{"id":"6d6435ae-0237-4d60-8f36-4d590cc7da4e","name":"RHEL10 - Unsubscribed host - 10.11","status":"complete","outcome":"passed","runTime":1381.492621,"created":"2026-08-10T10:38:30.119005","updated":"2026-08-10T10:38:30.119013","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d6435ae-0237-4d60-8f36-4d590cc7da4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d6435ae-0237-4d60-8f36-4d590cc7da4e/pipeline.log\">pipeline</a>"]},{"id":"6f07c5ce-ea7b-4496-a431-e66ceda2d4de","name":"RHEL10 - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1890.062735,"created":"2026-08-10T10:48:38.166093","updated":"2026-08-10T10:48:38.166099","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f07c5ce-ea7b-4496-a431-e66ceda2d4de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f07c5ce-ea7b-4496-a431-e66ceda2d4de/pipeline.log\">pipeline</a>"]},{"id":"27de2044-527c-4610-a909-3b8f72eb44a9","name":"RHEL10 - Unsubscribed host - PyTest - 11.8","status":"complete","outcome":"passed","runTime":1412.004344,"created":"2026-08-10T10:52:37.736046","updated":"2026-08-10T10:52:37.736053","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27de2044-527c-4610-a909-3b8f72eb44a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27de2044-527c-4610-a909-3b8f72eb44a9/pipeline.log\">pipeline</a>"]},{"id":"ece0c77d-34d2-4792-a4e7-d4495016147c","name":"RHEL8 - PyTest - 10.3","status":"complete","outcome":"passed","runTime":1761.034421,"created":"2026-08-10T10:44:40.277860","updated":"2026-08-10T10:44:40.277868","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ece0c77d-34d2-4792-a4e7-d4495016147c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ece0c77d-34d2-4792-a4e7-d4495016147c/pipeline.log\">pipeline</a>"]},{"id":"51ed8615-a306-4dae-93c6-19e12120fa2c","name":"CentOS Stream 9 - 10.5","status":"complete","outcome":"passed","runTime":1029.886564,"created":"2026-08-10T10:48:37.545159","updated":"2026-08-10T10:48:37.545167","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/51ed8615-a306-4dae-93c6-19e12120fa2c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/51ed8615-a306-4dae-93c6-19e12120fa2c/pipeline.log\">pipeline</a>"]}]} -->